### PR TITLE
feat(metrics): add Prometheus metrics for hot-reload operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Prometheus metrics for hot-reload operations** — three new domain-specific metrics exposed at `/metrics`:
+  - `homeassistant_reload_total{component, result}` — counter per component (automation/scene/script) and result (success/failed/skipped)
+  - `homeassistant_reload_duration_seconds{component}` — histogram (buckets: 0.5s–30s) for reload latency percentiles
+  - `homeassistant_reload_retries_total{component}` — extra retry attempts beyond the first; non-zero value indicates the reload required more than one attempt
+  - All data sourced from existing `ReloadResult` fields — no additional API calls required
+
 - **HomeAssistantAutomation CRD**: Declarative automation management with hot-reload capabilities
   - Full automation definition via CRD with triggers, conditions, and actions
   - Uses `runtime.RawExtension` for flexible YAML compatibility with Home Assistant syntax

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// reloadTotal counts hot-reload operations by component and result.
+	// result label: "success", "failed", "skipped"
+	reloadTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "homeassistant_reload_total",
+			Help: "Total number of Home Assistant component reload operations.",
+		},
+		[]string{"component", "result"},
+	)
+
+	// reloadDuration measures how long each reload operation takes.
+	reloadDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "homeassistant_reload_duration_seconds",
+			Help:    "Duration of Home Assistant component reload operations in seconds.",
+			Buckets: []float64{0.5, 1, 2, 5, 10, 15, 30},
+		},
+		[]string{"component"},
+	)
+
+	// reloadRetriesTotal counts extra retry attempts (attempts - 1) per component.
+	reloadRetriesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "homeassistant_reload_retries_total",
+			Help: "Total number of retry attempts during Home Assistant component reload operations.",
+		},
+		[]string{"component"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(reloadTotal, reloadDuration, reloadRetriesTotal)
+}

--- a/internal/controller/reload_helpers.go
+++ b/internal/controller/reload_helpers.go
@@ -48,6 +48,21 @@ func PerformReloadWithRetry(
 		ReloadID: uuid.New().String()[:8],
 	}
 	startTime := time.Now()
+
+	// Metrics defer runs SECOND (declared first = LIFO), after Duration is set below.
+	defer func() {
+		resultLabel := result.Method
+		if resultLabel == reloadMethodHotReload {
+			resultLabel = "success"
+		}
+		reloadTotal.WithLabelValues(config.ComponentName, resultLabel).Inc()
+		reloadDuration.WithLabelValues(config.ComponentName).Observe(result.Duration.Seconds())
+		if result.Attempts > 1 {
+			reloadRetriesTotal.WithLabelValues(config.ComponentName).Add(float64(result.Attempts - 1))
+		}
+	}()
+
+	// Duration defer runs FIRST (declared last = LIFO).
 	defer func() {
 		result.Duration = time.Since(startTime)
 	}()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for hot-reload operations: per-component reload counts (result labels), latency histogram (0.5–30s buckets), and retry counters.
  * Expanded HomeAssistantAutomation CRD: aggregation via a ConfigMap, finalizer-driven ConfigMap regeneration on delete, enable/disable via spec.enabled, and short names (haautomation, haauto).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->