### PR TITLE
fix(auto_include): restore tags stripped by YAML round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Primary: k3s on Raspberry Pi 4/5 (ARM64)
 - Also supported: Any Kubernetes cluster (AMD64/ARM64)
 
-[Unreleased]: https://github.com/przemekhys/homeassistant-operator/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/przemekhys/homeassistant-operator/compare/v0.7.1...HEAD
+[v0.7.1]: https://github.com/przemekhys/homeassistant-operator/compare/v0.7.0...v0.7.1
+[v0.7.0]: https://github.com/przemekhys/homeassistant-operator/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/przemekhys/homeassistant-operator/releases/tag/v0.6.0
 [0.5.1]: https://github.com/przemekhys/homeassistant-operator/releases/tag/v0.5.1
 [0.5.0]: https://github.com/przemekhys/homeassistant-operator/releases/tag/v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v0.7.1] - 2026-03-19
+
+
+### Fixed
+
+- **`auto_include` strips `!include` tags after YAML round-trip** — when `injectLocation` re-serialised `configuration.yaml`, the `!include` YAML tag was lost (e.g. `automation: !include automations.yaml` became `automation: automations.yaml`). HA treated the bare filename as a literal string and disabled all automations. `ensureAutoIncludes` now detects bare filenames and restores the `!include` directive in-place.
+
+
 ## [v0.7.0] - 2026-03-17
 
 ### Added

--- a/internal/controller/auto_include.go
+++ b/internal/controller/auto_include.go
@@ -128,22 +128,35 @@ func ensureAutoIncludes(configYAML string) string {
 		parsed = make(map[string]interface{})
 	}
 
+	result := configYAML
 	var additions []string
 	for _, entry := range autoIncludeEntries {
-		if _, exists := parsed[entry.key]; !exists {
+		val, exists := parsed[entry.key]
+		if !exists {
 			additions = append(additions, entry.key+": !include "+entry.fileName)
+		} else if strVal, ok := val.(string); ok && strVal == entry.fileName {
+			// Bare filename without !include tag — lost during YAML round-trip
+			// (e.g. injectLocation's yaml.Marshal strips !include tags).
+			// Fix in-place by restoring the !include directive.
+			result = strings.Replace(
+				result,
+				entry.key+": "+entry.fileName,
+				entry.key+": !include "+entry.fileName,
+				1,
+			)
 		}
 	}
 
-	if len(additions) == 0 {
+	if len(additions) == 0 && result == configYAML {
 		return configYAML
 	}
 
-	result := configYAML
-	// Ensure trailing newline before appending
-	if result != "" && !strings.HasSuffix(result, "\n") {
-		result += "\n"
+	if len(additions) > 0 {
+		// Ensure trailing newline before appending
+		if result != "" && !strings.HasSuffix(result, "\n") {
+			result += "\n"
+		}
+		result += strings.Join(additions, "\n") + "\n"
 	}
-	result += strings.Join(additions, "\n") + "\n"
 	return result
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where YAML include directives (e.g., !include automations.yaml) could be lost during config processing, leading Home Assistant to treat them as literal file paths and disable automations. The update now detects these cases and restores include directives in-place or appends missing includes so automations remain intact after configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->