### PR TITLE
feat(integration): add jsonValue field for JSON object config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`jsonValue` field for `HomeAssistantIntegration`** — new field in `IntegrationValue` that accepts a JSON-encoded string and submits it as a native JSON object to the Config Flow API. Fixes integrations like `openweathermap` that require dict-type fields (e.g. `location: {"latitude": 54.17, "longitude": 18.55}`). Example: `location: { jsonValue: '{"latitude": 54.17, "longitude": 18.55}' }`.
+
 - **Documentation site** — MkDocs Material documentation deployed to GitHub Pages (`https://przemekhys.github.io/homeassistant-operator/`). Includes getting started guides, CRD API reference auto-generated from Go type comments (`make docs-api`), and changelog auto-included from `CHANGELOG.md`. New Makefile targets: `make docs-serve`, `make docs-build`, `make docs-api`.
 
 - **Auto-unban operator IP from HA `ip_bans.yaml`** — when HA returns 403/429 (operator IP banned after too many failed login attempts), the operator automatically execs into the HA pod, removes its IP from `/config/ip_bans.yaml`, and deletes the pod so StatefulSet recreates it (clears in-memory bans). Limits: at most 5 unbans total, 5-minute cooldown between each. Once the limit is reached a `SelfUnbanLimitReached` warning event is emitted and manual intervention is required. New status fields: `selfUnbanCount`, `lastSelfUnban`. New event reasons: `SelfUnbanned`, `SelfUnbanFailed`, `SelfUnbanLimitReached`. Requires `POD_IP` env var (injected via downward API) and new RBAC `pods/exec create`.

--- a/api/v1alpha1/homeassistantintegration_types.go
+++ b/api/v1alpha1/homeassistantintegration_types.go
@@ -37,7 +37,7 @@ type HomeAssistantIntegrationSpec struct {
 }
 
 // IntegrationValue holds a plain text value, a JSON value, or a reference to a Kubernetes Secret key.
-// Exactly one of Value, JsonValue, or SecretKeyRef must be set.
+// Exactly one of Value, JSONValue, or SecretKeyRef must be set.
 // +kubebuilder:validation:XValidation:rule="has(self.value) || has(self.jsonValue) || has(self.secretKeyRef)",message="at least one of value, jsonValue, or secretKeyRef must be set"
 // +kubebuilder:validation:XValidation:rule="!(has(self.value) && has(self.jsonValue)) && !(has(self.value) && has(self.secretKeyRef)) && !(has(self.jsonValue) && has(self.secretKeyRef))",message="only one of value, jsonValue, or secretKeyRef may be set"
 type IntegrationValue struct {
@@ -45,11 +45,11 @@ type IntegrationValue struct {
 	// +optional
 	Value *string `json:"value,omitempty"`
 
-	// JsonValue is a JSON-encoded value that will be parsed and sent as a native JSON
+	// JSONValue is a JSON-encoded value that will be parsed and sent as a native JSON
 	// object to the Config Flow API. Use this for fields that expect a dictionary or
 	// array (e.g. location: '{"latitude": 54.17, "longitude": 18.55}').
 	// +optional
-	JsonValue *string `json:"jsonValue,omitempty"`
+	JSONValue *string `json:"jsonValue,omitempty"`
 
 	// SecretKeyRef references a key in a Kubernetes Secret
 	// +optional

--- a/api/v1alpha1/homeassistantintegration_types.go
+++ b/api/v1alpha1/homeassistantintegration_types.go
@@ -36,13 +36,20 @@ type HomeAssistantIntegrationSpec struct {
 	Configuration map[string]IntegrationValue `json:"configuration,omitempty"`
 }
 
-// IntegrationValue holds either a plain text value or a reference to a Kubernetes Secret key.
-// Exactly one of Value or SecretKeyRef must be set.
-// +kubebuilder:validation:XValidation:rule="(has(self.value) && !has(self.secretKeyRef)) || (!has(self.value) && has(self.secretKeyRef))",message="exactly one of value or secretKeyRef must be set"
+// IntegrationValue holds a plain text value, a JSON value, or a reference to a Kubernetes Secret key.
+// Exactly one of Value, JsonValue, or SecretKeyRef must be set.
+// +kubebuilder:validation:XValidation:rule="has(self.value) || has(self.jsonValue) || has(self.secretKeyRef)",message="at least one of value, jsonValue, or secretKeyRef must be set"
+// +kubebuilder:validation:XValidation:rule="!(has(self.value) && has(self.jsonValue)) && !(has(self.value) && has(self.secretKeyRef)) && !(has(self.jsonValue) && has(self.secretKeyRef))",message="only one of value, jsonValue, or secretKeyRef may be set"
 type IntegrationValue struct {
-	// Value is a plain text configuration value
+	// Value is a plain text configuration value sent as a string to the Config Flow API.
 	// +optional
 	Value *string `json:"value,omitempty"`
+
+	// JsonValue is a JSON-encoded value that will be parsed and sent as a native JSON
+	// object to the Config Flow API. Use this for fields that expect a dictionary or
+	// array (e.g. location: '{"latitude": 54.17, "longitude": 18.55}').
+	// +optional
+	JsonValue *string `json:"jsonValue,omitempty"`
 
 	// SecretKeyRef references a key in a Kubernetes Secret
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1498,6 +1498,11 @@ func (in *IntegrationValue) DeepCopyInto(out *IntegrationValue) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.JsonValue != nil {
+		in, out := &in.JsonValue, &out.JsonValue
+		*out = new(string)
+		**out = **in
+	}
 	if in.SecretKeyRef != nil {
 		in, out := &in.SecretKeyRef, &out.SecretKeyRef
 		*out = new(IntegrationSecretKeyRef)

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1498,8 +1498,8 @@ func (in *IntegrationValue) DeepCopyInto(out *IntegrationValue) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.JsonValue != nil {
-		in, out := &in.JsonValue, &out.JsonValue
+	if in.JSONValue != nil {
+		in, out := &in.JSONValue, &out.JSONValue
 		*out = new(string)
 		**out = **in
 	}

--- a/config/crd/bases/ha.homeassistant.io_homeassistantintegrations.yaml
+++ b/config/crd/bases/ha.homeassistant.io_homeassistantintegrations.yaml
@@ -64,9 +64,15 @@ spec:
               configuration:
                 additionalProperties:
                   description: |-
-                    IntegrationValue holds either a plain text value or a reference to a Kubernetes Secret key.
-                    Exactly one of Value or SecretKeyRef must be set.
+                    IntegrationValue holds a plain text value, a JSON value, or a reference to a Kubernetes Secret key.
+                    Exactly one of Value, JsonValue, or SecretKeyRef must be set.
                   properties:
+                    jsonValue:
+                      description: |-
+                        JsonValue is a JSON-encoded value that will be parsed and sent as a native JSON
+                        object to the Config Flow API. Use this for fields that expect a dictionary or
+                        array (e.g. location: '{"latitude": 54.17, "longitude": 18.55}').
+                      type: string
                     secretKeyRef:
                       description: SecretKeyRef references a key in a Kubernetes Secret
                       properties:
@@ -83,13 +89,18 @@ spec:
                       - name
                       type: object
                     value:
-                      description: Value is a plain text configuration value
+                      description: Value is a plain text configuration value sent
+                        as a string to the Config Flow API.
                       type: string
                   type: object
                   x-kubernetes-validations:
-                  - message: exactly one of value or secretKeyRef must be set
-                    rule: (has(self.value) && !has(self.secretKeyRef)) || (!has(self.value)
-                      && has(self.secretKeyRef))
+                  - message: at least one of value, jsonValue, or secretKeyRef must
+                      be set
+                    rule: has(self.value) || has(self.jsonValue) || has(self.secretKeyRef)
+                  - message: only one of value, jsonValue, or secretKeyRef may be
+                      set
+                    rule: '!(has(self.value) && has(self.jsonValue)) && !(has(self.value)
+                      && has(self.secretKeyRef)) && !(has(self.jsonValue) && has(self.secretKeyRef))'
                 description: |-
                   Configuration contains fields submitted to the Config Flow (single-step flows only).
                   Keys are field names from the data_schema; values are plain text or Secret references.

--- a/config/crd/bases/ha.homeassistant.io_homeassistantintegrations.yaml
+++ b/config/crd/bases/ha.homeassistant.io_homeassistantintegrations.yaml
@@ -65,11 +65,11 @@ spec:
                 additionalProperties:
                   description: |-
                     IntegrationValue holds a plain text value, a JSON value, or a reference to a Kubernetes Secret key.
-                    Exactly one of Value, JsonValue, or SecretKeyRef must be set.
+                    Exactly one of Value, JSONValue, or SecretKeyRef must be set.
                   properties:
                     jsonValue:
                       description: |-
-                        JsonValue is a JSON-encoded value that will be parsed and sent as a native JSON
+                        JSONValue is a JSON-encoded value that will be parsed and sent as a native JSON
                         object to the Config Flow API. Use this for fields that expect a dictionary or
                         array (e.g. location: '{"latitude": 54.17, "longitude": 18.55}').
                       type: string

--- a/internal/controller/homeassistantintegration_controller.go
+++ b/internal/controller/homeassistantintegration_controller.go
@@ -362,14 +362,19 @@ func (r *HomeAssistantIntegrationReconciler) resolveConfiguration(
 			fp.plainValues[key] = *val.Value
 			continue
 		}
-		if val.JsonValue != nil {
+		if val.JSONValue != nil {
 			var parsed interface{}
-			if err := json.Unmarshal([]byte(*val.JsonValue), &parsed); err != nil {
+			if err := json.Unmarshal([]byte(*val.JSONValue), &parsed); err != nil {
 				return nil, configFingerprint{}, fmt.Errorf(
 					"field %q: jsonValue is not valid JSON: %w", key, err)
 			}
+			canonical, err := json.Marshal(parsed)
+			if err != nil {
+				return nil, configFingerprint{}, fmt.Errorf(
+					"field %q: failed to re-marshal jsonValue: %w", key, err)
+			}
 			resolved[key] = parsed
-			fp.plainValues[key] = *val.JsonValue
+			fp.plainValues[key] = string(canonical)
 			continue
 		}
 		if val.SecretKeyRef != nil {

--- a/internal/controller/homeassistantintegration_controller.go
+++ b/internal/controller/homeassistantintegration_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -359,6 +360,16 @@ func (r *HomeAssistantIntegrationReconciler) resolveConfiguration(
 		if val.Value != nil {
 			resolved[key] = *val.Value
 			fp.plainValues[key] = *val.Value
+			continue
+		}
+		if val.JsonValue != nil {
+			var parsed interface{}
+			if err := json.Unmarshal([]byte(*val.JsonValue), &parsed); err != nil {
+				return nil, configFingerprint{}, fmt.Errorf(
+					"field %q: jsonValue is not valid JSON: %w", key, err)
+			}
+			resolved[key] = parsed
+			fp.plainValues[key] = *val.JsonValue
 			continue
 		}
 		if val.SecretKeyRef != nil {

--- a/internal/controller/homeassistantintegration_controller_test.go
+++ b/internal/controller/homeassistantintegration_controller_test.go
@@ -475,6 +475,85 @@ var _ = Describe("HomeAssistantIntegration Controller", func() {
 			Eventually(submitted, timeout, interval).Should(Receive(HaveKeyWithValue("broker", "mosquitto.default.svc")))
 		})
 
+		It("should submit jsonValue fields as native JSON objects", func() {
+			integration := &hav1alpha1.HomeAssistantIntegration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "int-json-config",
+					Namespace: namespace,
+				},
+				Spec: hav1alpha1.HomeAssistantIntegrationSpec{
+					HomeAssistantRef: hav1alpha1.HomeAssistantReference{Name: haName},
+					Domain:           "openweathermap",
+					Configuration: map[string]hav1alpha1.IntegrationValue{
+						"api_key":  {Value: ptr.To("test-api-key")},
+						"location": {JsonValue: ptr.To(`{"latitude": 54.17708, "longitude": 18.557}`)},
+						"mode":     {Value: ptr.To("forecast")},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, integration)).To(Succeed())
+
+			mockServer.Close()
+			submitted := make(chan map[string]interface{}, 1)
+			mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/api/config/config_entries/entry":
+					_ = json.NewEncoder(w).Encode([]haclient.ConfigEntry{})
+				case r.Method == http.MethodPost && r.URL.Path == "/api/config/config_entries/flow":
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"flow_id": "flow-json-001", "type": "form", "data_schema": []interface{}{},
+					})
+				case r.Method == http.MethodPost:
+					var body map[string]interface{}
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					submitted <- body
+					result, _ := json.Marshal(map[string]interface{}{
+						"entry_id": "json-entry-001", "domain": "openweathermap", "title": "OpenWeatherMap",
+					})
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"flow_id": "flow-json-001", "type": "create_entry", "result": json.RawMessage(result),
+					})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			reconciler.NewHAClient = func(_ string) *haclient.Client { return haclient.NewClient(mockServer.URL) }
+
+			Expect(reconcileIntegrationTwice("int-json-config")).To(Succeed())
+
+			Eventually(submitted, timeout, interval).Should(Receive(And(
+				HaveKeyWithValue("api_key", "test-api-key"),
+				HaveKeyWithValue("mode", "forecast"),
+				HaveKey("location"),
+			)))
+		})
+
+		It("should fail resolution when jsonValue is invalid JSON", func() {
+			integration := &hav1alpha1.HomeAssistantIntegration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "int-bad-json",
+					Namespace: namespace,
+				},
+				Spec: hav1alpha1.HomeAssistantIntegrationSpec{
+					HomeAssistantRef: hav1alpha1.HomeAssistantReference{Name: haName},
+					Domain:           "openweathermap",
+					Configuration: map[string]hav1alpha1.IntegrationValue{
+						"location": {JsonValue: ptr.To(`not valid json`)},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, integration)).To(Succeed())
+			Expect(reconcileIntegrationTwice("int-bad-json")).To(Succeed())
+
+			updated := &hav1alpha1.HomeAssistantIntegration{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "int-bad-json", Namespace: namespace}, updated)).To(Succeed())
+			cond := meta.FindStatusCondition(updated.Status.Conditions, conditionTypeIntegrationReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(reasonSecretResolutionFailed))
+		})
+
 		It("should resolve configuration from Kubernetes Secret", func() {
 			// Create a secret with the broker value
 			secret := &corev1.Secret{

--- a/internal/controller/homeassistantintegration_controller_test.go
+++ b/internal/controller/homeassistantintegration_controller_test.go
@@ -486,7 +486,7 @@ var _ = Describe("HomeAssistantIntegration Controller", func() {
 					Domain:           "openweathermap",
 					Configuration: map[string]hav1alpha1.IntegrationValue{
 						"api_key":  {Value: ptr.To("test-api-key")},
-						"location": {JsonValue: ptr.To(`{"latitude": 54.17708, "longitude": 18.557}`)},
+						"location": {JSONValue: ptr.To(`{"latitude": 54.17708, "longitude": 18.557}`)},
 						"mode":     {Value: ptr.To("forecast")},
 					},
 				},
@@ -525,7 +525,7 @@ var _ = Describe("HomeAssistantIntegration Controller", func() {
 			Eventually(submitted, timeout, interval).Should(Receive(And(
 				HaveKeyWithValue("api_key", "test-api-key"),
 				HaveKeyWithValue("mode", "forecast"),
-				HaveKey("location"),
+				HaveKeyWithValue("location", BeAssignableToTypeOf(map[string]interface{}{})),
 			)))
 		})
 
@@ -539,7 +539,7 @@ var _ = Describe("HomeAssistantIntegration Controller", func() {
 					HomeAssistantRef: hav1alpha1.HomeAssistantReference{Name: haName},
 					Domain:           "openweathermap",
 					Configuration: map[string]hav1alpha1.IntegrationValue{
-						"location": {JsonValue: ptr.To(`not valid json`)},
+						"location": {JSONValue: ptr.To(`not valid json`)},
 					},
 				},
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for JSON-encoded configuration values in Home Assistant integrations so nested objects (e.g., location dicts) are submitted as native JSON.
  * Validation updated to require one of value/jsonValue/secretKeyRef and enforce mutual exclusivity among them.

* **Tests**
  * Added tests verifying proper submission of JSON values and error handling when provided JSON is invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->