### PR TITLE
fix(ban-recovery): handle multi-document ip_bans.yaml in unban init-c…

### DIFF
--- a/internal/controller/homeassistant_controller.go
+++ b/internal/controller/homeassistant_controller.go
@@ -1359,14 +1359,22 @@ if not ip:
 path = os.environ.get('UNBAN_IP_BANS_PATH', '/config/ip_bans.yaml')
 if not os.path.exists(path):
     sys.exit(0)
-with open(path) as f:
-    content = f.read()
+try:
+    with open(path) as f:
+        content = f.read()
+except OSError:
+    sys.exit(0)
 content = content.strip()
 if not content or content == '{}':
     sys.exit(0)
-if content.startswith('{}'):
-    content = content[2:].lstrip()
-d = yaml.safe_load(content) or {}
+while content.startswith('{}'):
+    content = content[2:].strip()
+if not content:
+    sys.exit(0)
+try:
+    d = yaml.safe_load(content) or {}
+except yaml.YAMLError:
+    sys.exit(0)
 if ip not in d:
     sys.exit(0)
 del d[ip]

--- a/internal/controller/homeassistant_controller.go
+++ b/internal/controller/homeassistant_controller.go
@@ -1363,7 +1363,10 @@ with open(path) as f:
     content = f.read()
 if not content.strip():
     sys.exit(0)
-d = yaml.safe_load(content) or {}
+d = {}
+for doc in yaml.safe_load_all(content):
+    if isinstance(doc, dict):
+        d.update(doc)
 if ip not in d:
     sys.exit(0)
 del d[ip]

--- a/internal/controller/homeassistant_controller.go
+++ b/internal/controller/homeassistant_controller.go
@@ -1356,17 +1356,17 @@ import yaml, os, sys
 ip = os.environ.get('OPERATOR_IP', '')
 if not ip:
     sys.exit(0)
-path = '/config/ip_bans.yaml'
+path = os.environ.get('UNBAN_IP_BANS_PATH', '/config/ip_bans.yaml')
 if not os.path.exists(path):
     sys.exit(0)
 with open(path) as f:
     content = f.read()
-if not content.strip():
+content = content.strip()
+if not content or content == '{}':
     sys.exit(0)
-d = {}
-for doc in yaml.safe_load_all(content):
-    if isinstance(doc, dict):
-        d.update(doc)
+if content.startswith('{}'):
+    content = content[2:].lstrip()
+d = yaml.safe_load(content) or {}
 if ip not in d:
     sys.exit(0)
 del d[ip]

--- a/internal/controller/homeassistant_controller_test.go
+++ b/internal/controller/homeassistant_controller_test.go
@@ -1647,7 +1647,8 @@ var _ = Describe("HomeAssistant Controller", func() {
 		It("removes operator IP from multi-doc YAML produced by HA appending to {}", func() {
 			// HA appends ban entries to a file containing '{}' without a '---' separator;
 			// yaml.safe_load crashes on this input — verify the {} prefix is stripped first.
-			content := "{}\n\n10.42.1.5:\n  banned_at: '2026-07-03T12:11:50+00:00'\n1.2.3.4:\n  banned_at: '2026-07-03T09:00:00+00:00'\n"
+			content := "{}\n\n10.42.1.5:\n  banned_at: '2026-07-03T12:11:50+00:00'\n" +
+				"1.2.3.4:\n  banned_at: '2026-07-03T09:00:00+00:00'\n"
 			result, err := runUnbanScript("10.42.1.5", content)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(ContainSubstring("10.42.1.5"))
@@ -1660,6 +1661,21 @@ var _ = Describe("HomeAssistant Controller", func() {
 			result, err := runUnbanScript("10.42.1.5", content)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal("{}"))
+		})
+
+		It("strips repeated {} prefixes before parsing", func() {
+			// HA may append after multiple resets, producing {}\n{}\n<ip>: ...
+			content := "{}\n{}\n10.42.1.5:\n  banned_at: '2026-07-03T12:11:50+00:00'\n"
+			result, err := runUnbanScript("10.42.1.5", content)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(ContainSubstring("10.42.1.5"))
+		})
+
+		It("exits cleanly on unparseable YAML content", func() {
+			// Corrupted or otherwise invalid YAML must not crash the init-container.
+			content := "key: [unclosed bracket\n"
+			_, err := runUnbanScript("10.42.1.5", content)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("does not modify file when operator IP is not present", func() {

--- a/internal/controller/homeassistant_controller_test.go
+++ b/internal/controller/homeassistant_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"os"
+	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1610,6 +1611,63 @@ var _ = Describe("HomeAssistant Controller", func() {
 			}, sts)).To(Succeed())
 			Expect(sts.Spec.Template.Spec.HostNetwork).To(BeFalse())
 			Expect(sts.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSClusterFirst))
+		})
+	})
+
+	Context("unban script multi-document YAML parsing", func() {
+		var script string
+
+		BeforeEach(func() {
+			if _, err := exec.LookPath("python3"); err != nil {
+				Skip("python3 not available")
+			}
+			r := &HomeAssistantReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			ha := &hav1.HomeAssistant{
+				ObjectMeta: metav1.ObjectMeta{Name: "script-parse-test", Namespace: "default"},
+				Spec:       hav1.HomeAssistantSpec{Version: "2024.1.0"},
+			}
+			script = r.buildUnbanInitContainer(ha).Command[2]
+		})
+
+		runUnbanScript := func(operatorIP, fileContent string) (string, error) {
+			f, err := os.CreateTemp("", "ip_bans_*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { _ = os.Remove(f.Name()) })
+			_, err = f.WriteString(fileContent)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(f.Close()).NotTo(HaveOccurred())
+			cmd := exec.Command("python3", "-c", script)
+			cmd.Env = append(os.Environ(), "OPERATOR_IP="+operatorIP, "UNBAN_IP_BANS_PATH="+f.Name())
+			_, runErr := cmd.Output()
+			data, readErr := os.ReadFile(f.Name())
+			Expect(readErr).NotTo(HaveOccurred())
+			return string(data), runErr
+		}
+
+		It("removes operator IP from multi-doc YAML produced by HA appending to {}", func() {
+			// HA appends ban entries to a file containing '{}' without a '---' separator;
+			// yaml.safe_load crashes on this input — verify the {} prefix is stripped first.
+			content := "{}\n\n10.42.1.5:\n  banned_at: '2026-07-03T12:11:50+00:00'\n1.2.3.4:\n  banned_at: '2026-07-03T09:00:00+00:00'\n"
+			result, err := runUnbanScript("10.42.1.5", content)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(ContainSubstring("10.42.1.5"))
+			Expect(result).To(ContainSubstring("1.2.3.4"))
+		})
+
+		It("exits cleanly when file contains only {}", func() {
+			// A file reset to '{}' with no bans must not cause a crash or modify the file.
+			content := "{}"
+			result, err := runUnbanScript("10.42.1.5", content)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("{}"))
+		})
+
+		It("does not modify file when operator IP is not present", func() {
+			// Verifies the ip-not-in-d early-exit: other IPs must remain untouched.
+			content := "1.2.3.4:\n  banned_at: '2026-07-03T09:00:00+00:00'\n"
+			result, err := runUnbanScript("10.42.1.5", content)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(content))
 		})
 	})
 


### PR DESCRIPTION
…ontainer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unbanning reliability for IP ban configuration files that include multiple YAML documents or appended sections.
  * Unban behavior is now more robust when the bans file is missing, empty, or contains only placeholder content (`{}`), treating these cases as a clean no-op.
  * The bans file path can now be controlled via `UNBAN_IP_BANS_PATH` (defaulting to `/config/ip_bans.yaml`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->