### PR TITLE
test(e2e): pin k3s and Home Assistant image versions

### DIFF
--- a/.github/workflows/test-e2e-parallel.yml
+++ b/.github/workflows/test-e2e-parallel.yml
@@ -9,8 +9,12 @@ permissions:
   contents: read
 
 env:
+  # renovate: datasource=github-releases depName=k3d-io/k3d
   K3D_VERSION: v5.7.4
-  HA_VERSION: stable
+  # renovate: datasource=docker depName=rancher/k3s
+  K3S_VERSION: v1.31.5-k3s1
+  # renovate: datasource=docker depName=ghcr.io/home-assistant/home-assistant
+  HA_VERSION: "2026.7.1"
 
 jobs:
   # Job 1: Build and cache operator image
@@ -79,6 +83,7 @@ jobs:
       - name: Create k3d cluster
         run: |
           k3d cluster create e2e-critical \
+            --image rancher/k3s:${{ env.K3S_VERSION }} \
             --agents 0 \
             --servers-memory 12g \
             --wait \

--- a/Makefile
+++ b/Makefile
@@ -120,19 +120,23 @@ test: manifests generate fmt vet setup-envtest ## Run unit tests.
 # E2E tests use k3d (recommended for k3s-like target environments)
 K3D_CLUSTER_E2E ?= homeassistant-operator-test-e2e
 K3D_MEMORY_E2E ?= 12g
+# renovate: datasource=docker depName=rancher/k3s
+K3S_VERSION ?= v1.31.5-k3s1
+# renovate: datasource=docker depName=ghcr.io/home-assistant/home-assistant
+HA_VERSION ?= 2026.7.1
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a k3d cluster for e2e tests (always creates fresh cluster)
 	@command -v k3d >/dev/null 2>&1 || { echo "k3d is not installed. Install with: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"; exit 1; }
 	@echo "Ensuring clean k3d cluster state..."
 	@k3d cluster delete $(K3D_CLUSTER_E2E) 2>/dev/null || true
-	@echo "Creating fresh k3d cluster $(K3D_CLUSTER_E2E) with $(K3D_MEMORY_E2E) memory..."
-	@k3d cluster create $(K3D_CLUSTER_E2E) --agents 0 --servers-memory $(K3D_MEMORY_E2E)
-	@echo "Ensuring Home Assistant image is in local Docker cache..."
-	@docker image inspect ghcr.io/home-assistant/home-assistant:stable >/dev/null 2>&1 || \
-		docker pull ghcr.io/home-assistant/home-assistant:stable
+	@echo "Creating fresh k3d cluster $(K3D_CLUSTER_E2E) with $(K3D_MEMORY_E2E) memory (k3s $(K3S_VERSION))..."
+	@k3d cluster create $(K3D_CLUSTER_E2E) --image rancher/k3s:$(K3S_VERSION) --agents 0 --servers-memory $(K3D_MEMORY_E2E)
+	@echo "Ensuring Home Assistant image $(HA_VERSION) is in local Docker cache..."
+	@docker image inspect ghcr.io/home-assistant/home-assistant:$(HA_VERSION) >/dev/null 2>&1 || \
+		docker pull ghcr.io/home-assistant/home-assistant:$(HA_VERSION)
 	@echo "Importing Home Assistant image from local Docker cache into k3d containerd..."
-	@k3d image import ghcr.io/home-assistant/home-assistant:stable -c $(K3D_CLUSTER_E2E)
+	@k3d image import ghcr.io/home-assistant/home-assistant:$(HA_VERSION) -c $(K3D_CLUSTER_E2E)
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ginkgo ## Run E2E critical path tests — 1 bootstrap, 11 tests (~40-50 min)
@@ -159,7 +163,7 @@ K3D_MEMORY ?= 12g
 .PHONY: k3d-create
 k3d-create: ## Create a k3d cluster for testing
 	@command -v k3d >/dev/null 2>&1 || { echo "k3d is not installed. Install with: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"; exit 1; }
-	@k3d cluster list | grep -q $(K3D_CLUSTER) && echo "Cluster $(K3D_CLUSTER) already exists" || k3d cluster create $(K3D_CLUSTER) --agents 0 --servers-memory $(K3D_MEMORY)
+	@k3d cluster list | grep -q $(K3D_CLUSTER) && echo "Cluster $(K3D_CLUSTER) already exists" || k3d cluster create $(K3D_CLUSTER) --image rancher/k3s:$(K3S_VERSION) --agents 0 --servers-memory $(K3D_MEMORY)
 
 .PHONY: k3d-delete
 k3d-delete: ## Delete the k3d test cluster

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
       "customType": "regex",
       "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$", "^Makefile$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+\\S+?[:=]\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+\\S+?\\s*(?:\\?=|[:=])\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
       ]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "timezone": "UTC",
   "schedule": ["at any time"],
-  "enabledManagers": ["gomod", "github-actions", "dockerfile"],
+  "enabledManagers": ["gomod", "github-actions", "dockerfile", "custom.regex"],
   "commitMessagePrefix": "chore(deps):",
   "dependencyDashboard": false,
   "packageRules": [
@@ -11,6 +11,15 @@
       "matchPackagePatterns": [".*"],
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "groupName": "all dependencies"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$", "^Makefile$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+\\S+?[:=]\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
+      ]
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test environment versions to use fixed, versioned images for more consistent end-to-end runs.
  * Improved cluster setup so the same k3s and Home Assistant versions are used across test commands.
* **Bug Fixes**
  * Reduced drift in test environments by removing reliance on moving “stable” image tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->