### PR TITLE
Sign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,12 +172,15 @@ jobs:
 
       # Keyless, same identity as the container image (see build-and-push). Signs
       # the pushed OCI artifact's own digest — cosign treats a Helm chart OCI
-      # artifact the same as a container image for signing purposes.
+      # artifact the same as a container image for signing purposes. CHART_REF
+      # carries the "oci://" scheme Helm needs; cosign's image reference parser
+      # has no such scheme and misreads "oci" as a registry hostname, so it must
+      # be stripped here.
       - name: Sign Helm chart
         env:
           CHART_REF: ${{ steps.chart.outputs.ref }}
           CHART_DIGEST: ${{ steps.chart.outputs.digest }}
-        run: cosign sign --yes "${CHART_REF}@${CHART_DIGEST}"
+        run: cosign sign --yes "${CHART_REF#oci://}@${CHART_DIGEST}"
 
   publish-release-assets:
     needs: [build-and-push, helm-publish]
@@ -284,6 +287,8 @@ jobs:
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             "${IMAGE}@${IMAGE_DIGEST}"
 
+      # CHART_REF carries the "oci://" scheme (needed by Helm); cosign has no
+      # such scheme and misreads "oci" as a hostname, so strip it here too.
       - name: Verify Helm chart signature
         env:
           IDENTITY_REGEXP: https://github.com/${{ github.repository }}/\.github/workflows/release\.yml@refs/tags/.*
@@ -293,7 +298,7 @@ jobs:
           cosign verify \
             --certificate-identity-regexp "$IDENTITY_REGEXP" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            "${CHART_REF}@${CHART_DIGEST}"
+            "${CHART_REF#oci://}@${CHART_DIGEST}"
 
       - name: Verify checksums manifest signature
         env:

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -120,6 +120,7 @@ jobs:
   e2e-k3d:
     name: fresh install + upgrade (k3d)
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # historical runs finish in 3-5 min; catches a hang instead of running to GitHub's 360min default
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/docs/user-guide/signed-releases.md
+++ b/docs/user-guide/signed-releases.md
@@ -139,8 +139,13 @@ cosign verify \
   --certificate-identity-regexp \
     'https://github.com/przemekhys/homeassistant-operator/\.github/workflows/release\.yml@refs/tags/.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  oci://ghcr.io/przemekhys/charts/homeassistant-operator@<chart-digest>
+  ghcr.io/przemekhys/charts/homeassistant-operator@<chart-digest>
 ```
+
+!!! note "No `oci://` prefix here"
+    That scheme is Helm-specific syntax for `helm install`/`push`. `cosign`
+    expects a bare `registry/repo@digest` — passing `oci://...` makes it try to
+    resolve `oci` itself as a registry hostname and fail.
 
 This check is independent of Kyverno and of any cluster — it works anywhere
 `cosign` can reach the OCI registry, for example as a preflight step in a GitOps

--- a/hack/verify-signatures.sh
+++ b/hack/verify-signatures.sh
@@ -42,7 +42,7 @@ CHART_DIGEST="$(crane digest "${CHART_REF#oci://}:${VERSION#v}")"
 cosign verify \
   --certificate-identity-regexp "$IDENTITY_REGEXP" \
   --certificate-oidc-issuer "$ISSUER" \
-  "${CHART_REF}@${CHART_DIGEST}"
+  "${CHART_REF#oci://}@${CHART_DIGEST}"
 
 echo "==> Verifying checksums.txt bundle from the ${VERSION} GitHub Release"
 WORKDIR="$(mktemp -d)"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm chart signature signing and verification when chart references use the `oci://` scheme.
  * Added a 10-minute limit to end-to-end Helm tests to prevent stalled runs.

* **Documentation**
  * Clarified signed Helm chart verification commands and explained when to omit the `oci://` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->