### PR TITLE
fix(ci): switch checksums.txt signing to cosign bundle format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,11 +216,13 @@ jobs:
           ${CHART_DIGEST}  helm-chart       ${CHART_REF}
           EOF
 
+      # cosign >=3.0 dropped --output-signature/--output-certificate for
+      # sign-blob in favor of a single --bundle file (signature + certificate +
+      # Rekor entry together).
       - name: Sign checksums manifest
         run: |
           cosign sign-blob --yes \
-            --output-signature checksums.txt.sig \
-            --output-certificate checksums.txt.pem \
+            --bundle checksums.txt.bundle \
             checksums.txt
 
       # Tags previously produced no GitHub Release object at all; this job
@@ -235,14 +237,14 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           REPO="${{ github.repository }}"
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
-            gh release upload "$TAG" checksums.txt checksums.txt.sig checksums.txt.pem \
+            gh release upload "$TAG" checksums.txt checksums.txt.bundle \
               --repo "$REPO" --clobber
           else
             gh release create "$TAG" \
               --repo "$REPO" \
               --title "$TAG" \
               --generate-notes \
-              checksums.txt checksums.txt.sig checksums.txt.pem
+              checksums.txt checksums.txt.bundle
           fi
 
   smoke-oci:
@@ -308,8 +310,7 @@ jobs:
           gh release download "${GITHUB_REF_NAME}" --repo "${{ github.repository }}" \
             -p 'checksums.txt*' --clobber
           cosign verify-blob \
-            --certificate checksums.txt.pem \
-            --signature checksums.txt.sig \
+            --bundle checksums.txt.bundle \
             --certificate-identity-regexp "$IDENTITY_REGEXP" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             checksums.txt

--- a/docs/user-guide/signed-releases.md
+++ b/docs/user-guide/signed-releases.md
@@ -44,8 +44,7 @@ digests transitively in one check):
 ```bash
 gh release download v1.2.0 -p 'checksums.txt*'
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.bundle \
   --certificate-identity-regexp \
     'https://github.com/przemekhys/homeassistant-operator/\.github/workflows/release\.yml@refs/tags/.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \

--- a/hack/verify-signatures.sh
+++ b/hack/verify-signatures.sh
@@ -49,8 +49,7 @@ WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
 gh release download "$VERSION" --repo "$REPO" -p 'checksums.txt*' --dir "$WORKDIR"
 cosign verify-blob \
-  --certificate "$WORKDIR/checksums.txt.pem" \
-  --signature "$WORKDIR/checksums.txt.sig" \
+  --bundle "$WORKDIR/checksums.txt.bundle" \
   --certificate-identity-regexp "$IDENTITY_REGEXP" \
   --certificate-oidc-issuer "$ISSUER" \
   "$WORKDIR/checksums.txt"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Security**
  * Release checksum signatures now use a single Cosign bundle artifact.
  * Updated release verification workflows and scripts to validate bundled signatures.
* **Documentation**
  * Updated signed-release instructions to reflect the new bundle-based verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->