### PR TITLE
fix(ci): stop trying to delete+recreate a published release, fail lou…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,8 +232,7 @@ jobs:
       # immutable-releases restriction, so this job just attaches the
       # checksums assets to it and publishes — everything set in the UI
       # survives untouched. This is a race against the earlier jobs; if the
-      # draft isn't there yet, or the release was published directly instead
-      # of left as a draft, fall back accordingly (see branches below). A
+      # draft isn't there yet, create fresh (see the final branch below). A
       # failure here fails the job the normal GitHub Actions way — no silent
       # unsigned/partial release.
       - name: Publish GitHub Release with signed checksums
@@ -251,30 +250,20 @@ jobs:
               gh release upload "$TAG" checksums.txt checksums.txt.bundle --repo "$REPO"
               gh release edit "$TAG" --repo "$REPO" --draft=false
             else
-              # Published directly instead of left as a draft. Can't attach
-              # assets to an immutable release, so rebuild it: preserve the
-              # title/notes/prerelease flag (the only fields recoverable
-              # from an already-published release; "latest" and discussion
-              # links, if set, are lost here and cannot be reapplied after
-              # publish either).
-              EXISTING_NAME="$(gh release view "$TAG" --repo "$REPO" --json name -q .name)"
-              EXISTING_BODY="$(gh release view "$TAG" --repo "$REPO" --json body -q .body)"
-              EXISTING_PRERELEASE="$(gh release view "$TAG" --repo "$REPO" --json isPrerelease -q .isPrerelease)"
-              gh release delete "$TAG" --repo "$REPO" --yes
-              TITLE="$TAG"
-              [ -n "$EXISTING_NAME" ] && TITLE="$EXISTING_NAME"
-              NOTES_ARGS=(--generate-notes)
-              [ -n "$EXISTING_BODY" ] && NOTES_ARGS=(--notes "$EXISTING_BODY")
-              PRERELEASE_ARGS=()
-              [ "$EXISTING_PRERELEASE" = "true" ] && PRERELEASE_ARGS=(--prerelease)
-              gh release create "$TAG" \
-                --repo "$REPO" \
-                --title "$TITLE" \
-                "${NOTES_ARGS[@]}" \
-                "${PRERELEASE_ARGS[@]}" \
-                --draft \
-                checksums.txt checksums.txt.bundle
-              gh release edit "$TAG" --repo "$REPO" --draft=false
+              # Published directly instead of left as a draft. Do NOT try to
+              # delete-and-recreate: GitHub permanently refuses to reuse a
+              # tag_name that was ever attached to an immutable release, even
+              # after deletion ("tag_name was used by an immutable release"),
+              # so a delete here only destroys a working release and leaves
+              # an orphaned "untagged-..." release behind instead — strictly
+              # worse than doing nothing. This needs a human: delete the tag
+              # (and, if one exists, the orphaned untagged release) and push
+              # a new one.
+              echo "::error::Release ${TAG} is already published (not a draft)." \
+                "Its assets are immutable and cannot be attached after the fact." \
+                "Delete the tag and push a new one; next time, save the release" \
+                "as a draft in the UI instead of publishing it directly." >&2
+              exit 1
             fi
           else
             # No draft made yet (lost the race, or skipped it for a quick


### PR DESCRIPTION
…dly instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release publishing now stops with a clear error when a release for the tag is already published.
  * Updated guidance explains how to create a new draft release when published assets need to be regenerated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->