### PR TITLE
fix(rbac): grant operator's own namespace webhook-cert RBAC in watchN…

### DIFF
--- a/charts/homeassistant-operator/templates/webhook-rbac.yaml
+++ b/charts/homeassistant-operator/templates/webhook-rbac.yaml
@@ -1,0 +1,68 @@
+{{- /*
+The self-managed webhook serving certificate (cert-controller) always creates/updates a
+Secret in the operator's own namespace and patches the cluster-scoped
+ValidatingWebhookConfiguration to inject its CA bundle — regardless of which namespaces
+are being watched for HomeAssistant CRs via watchNamespaces. When watchNamespaces is set,
+the broad manager-role ClusterRoleBinding is intentionally not created (least-privilege
+mode, see clusterrolebinding.yaml) and the operator's own namespace is not automatically
+part of watchNamespaces (see values.yaml) — so without these two narrowly scoped bindings
+the ServiceAccount cannot create the Secret and the operator crash-loops on startup.
+Skipped when cert-manager provides the serving certificate instead
+(webhook.certManager.enabled): cert-manager's own cainjector manages the Secret and CA
+injection using its own ServiceAccount, not this one.
+*/}}
+{{- if and .Values.webhook.enabled (not .Values.webhook.certManager.enabled) (not (empty .Values.watchNamespaces)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "homeassistant-operator.fullname" . }}-webhook-cert-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "homeassistant-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "list", "watch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "homeassistant-operator.fullname" . }}-webhook-cert-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "homeassistant-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "homeassistant-operator.fullname" . }}-webhook-cert-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "homeassistant-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "homeassistant-operator.fullname" . }}-webhook-cert-clusterrole
+  labels:
+    {{- include "homeassistant-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "homeassistant-operator.fullname" . }}-webhook-cert-clusterrolebinding
+  labels:
+    {{- include "homeassistant-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "homeassistant-operator.fullname" . }}-webhook-cert-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "homeassistant-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/homeassistant-operator/tests/rbac_binding_test.yaml
+++ b/charts/homeassistant-operator/tests/rbac_binding_test.yaml
@@ -67,15 +67,50 @@ tests:
         equal:
             path: metadata.namespace
             value: NAMESPACE
+      - documentIndex: 0
+        equal:
+            path: rules[0]
+            value:
+              apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["create", "get", "list", "watch", "update"]
       - documentIndex: 1
         isKind:
             of: RoleBinding
+      - documentIndex: 1
+        equal:
+            path: roleRef
+            value:
+              apiGroup: rbac.authorization.k8s.io
+              kind: Role
+              name: RELEASE-NAME-homeassistant-operator-webhook-cert-role
+      - documentIndex: 1
+        equal:
+            path: subjects[0]
+            value:
+              kind: ServiceAccount
+              name: RELEASE-NAME-homeassistant-operator
+              namespace: NAMESPACE
       - documentIndex: 2
         isKind:
             of: ClusterRole
+      - documentIndex: 2
+        equal:
+            path: rules[0]
+            value:
+              apiGroups: ["admissionregistration.k8s.io"]
+              resources: ["validatingwebhookconfigurations"]
+              verbs: ["get", "list", "watch", "update", "patch"]
       - documentIndex: 3
         isKind:
             of: ClusterRoleBinding
+      - documentIndex: 3
+        equal:
+            path: roleRef
+            value:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: RELEASE-NAME-homeassistant-operator-webhook-cert-clusterrole
 
   - it: skips webhook-cert RBAC when watchNamespaces is empty (ClusterRoleBinding already covers it)
     templates:

--- a/charts/homeassistant-operator/tests/rbac_binding_test.yaml
+++ b/charts/homeassistant-operator/tests/rbac_binding_test.yaml
@@ -50,3 +50,58 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "watchNamespaces contains a blank entry — each item must be a non-empty namespace name"
+
+  - it: grants the operator's own namespace webhook-cert RBAC when watchNamespaces excludes it (self-managed cert, default)
+    templates:
+      - webhook-rbac.yaml
+    set:
+      watchNamespaces:
+        - homeassistant
+    asserts:
+      - hasDocuments:
+          count: 4
+      - documentIndex: 0
+        isKind:
+            of: Role
+      - documentIndex: 0
+        equal:
+            path: metadata.namespace
+            value: NAMESPACE
+      - documentIndex: 1
+        isKind:
+            of: RoleBinding
+      - documentIndex: 2
+        isKind:
+            of: ClusterRole
+      - documentIndex: 3
+        isKind:
+            of: ClusterRoleBinding
+
+  - it: skips webhook-cert RBAC when watchNamespaces is empty (ClusterRoleBinding already covers it)
+    templates:
+      - webhook-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: skips webhook-cert RBAC when cert-manager provides the serving certificate
+    templates:
+      - webhook-rbac.yaml
+    set:
+      watchNamespaces:
+        - homeassistant
+      webhook.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: skips webhook-cert RBAC when the webhook is disabled
+    templates:
+      - webhook-rbac.yaml
+    set:
+      watchNamespaces:
+        - homeassistant
+      webhook.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,6 +137,7 @@ func main() {
 	// WATCH_NAMESPACES: comma-separated list of namespaces to watch.
 	// When empty, operator watches all namespaces (requires ClusterRoleBinding).
 	// When set, operator watches only listed namespaces (RoleBindings per namespace sufficient).
+	operatorNamespace := os.Getenv("OPERATOR_NAMESPACE")
 	var defaultNamespaces map[string]cache.Config
 	if watchNS := os.Getenv("WATCH_NAMESPACES"); watchNS != "" {
 		defaultNamespaces = make(map[string]cache.Config)
@@ -149,6 +150,13 @@ func main() {
 			setupLog.Error(nil, "WATCH_NAMESPACES is set but contains no valid namespace "+
 				"entries after trimming; refusing to start with empty scope")
 			os.Exit(1)
+		}
+		// The self-managed webhook serving-cert Secret (and its ValidatingWebhookConfiguration
+		// CA injection) always lives in the operator's own namespace, regardless of which
+		// namespaces are watched for HomeAssistant CRs — without this, cert-controller's
+		// informer for that Secret is never started even when RBAC allows the access.
+		if operatorNamespace != "" {
+			defaultNamespaces[operatorNamespace] = cache.Config{}
 		}
 		setupLog.Info("watching specific namespaces", "namespaces", watchNS)
 	} else {
@@ -179,7 +187,7 @@ func main() {
 	// Self-managed webhook needs the operator namespace (to write the Secret and
 	// patch the ValidatingWebhookConfiguration). When it is unset — typically local
 	// `make run` — skip the webhook instead of failing, so out-of-cluster dev works.
-	if enableWebhooks && webhookSelfManageCert && os.Getenv("OPERATOR_NAMESPACE") == "" {
+	if enableWebhooks && webhookSelfManageCert && operatorNamespace == "" {
 		setupLog.Info("OPERATOR_NAMESPACE not set; disabling the validating webhook " +
 			"(set ENABLE_WEBHOOKS=false to silence, or run in-cluster)")
 		enableWebhooks = false
@@ -386,7 +394,7 @@ func main() {
 	if enableWebhooks {
 		setupFinished := make(chan struct{})
 		if webhookSelfManageCert {
-			ns := os.Getenv("OPERATOR_NAMESPACE")
+			ns := operatorNamespace
 			svc := getenvOr("WEBHOOK_SERVICE_NAME", "homeassistant-operator-webhook-service")
 			secretName := getenvOr("WEBHOOK_SECRET_NAME", "homeassistant-operator-webhook-server-cert")
 			vwcName := getenvOr("WEBHOOK_CONFIG_NAME", "homeassistant-operator-validating-webhook-configuration")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -151,16 +151,28 @@ func main() {
 				"entries after trimming; refusing to start with empty scope")
 			os.Exit(1)
 		}
-		// The self-managed webhook serving-cert Secret (and its ValidatingWebhookConfiguration
-		// CA injection) always lives in the operator's own namespace, regardless of which
-		// namespaces are watched for HomeAssistant CRs — without this, cert-controller's
-		// informer for that Secret is never started even when RBAC allows the access.
-		if operatorNamespace != "" {
-			defaultNamespaces[operatorNamespace] = cache.Config{}
-		}
 		setupLog.Info("watching specific namespaces", "namespaces", watchNS)
 	} else {
 		setupLog.Info("watching all namespaces (set WATCH_NAMESPACES to restrict)")
+	}
+
+	// The self-managed webhook serving-cert Secret (and its ValidatingWebhookConfiguration
+	// CA injection) always lives in the operator's own namespace, regardless of which
+	// namespaces are watched for HomeAssistant CRs. Scope this to a Secret-only ByObject
+	// override rather than adding it to defaultNamespaces, which would broaden the cache
+	// to every namespaced type (StatefulSets, ConfigMaps, HA CRDs, ...) in that namespace.
+	var cacheByObject map[client.Object]cache.ByObject
+	if defaultNamespaces != nil && operatorNamespace != "" {
+		if _, ok := defaultNamespaces[operatorNamespace]; !ok {
+			secretNamespaces := make(map[string]cache.Config, len(defaultNamespaces)+1)
+			for ns, cfg := range defaultNamespaces {
+				secretNamespaces[ns] = cfg
+			}
+			secretNamespaces[operatorNamespace] = cache.Config{}
+			cacheByObject = map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {Namespaces: secretNamespaces},
+			}
+		}
 	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
@@ -294,7 +306,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "a26346d9.homeassistant.io",
-		Cache:                  cache.Options{DefaultNamespaces: defaultNamespaces},
+		Cache:                  cache.Options{DefaultNamespaces: defaultNamespaces, ByObject: cacheByObject},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
…amespaces mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved webhook certificate management when monitoring selected namespaces.
  * Added the required permissions for automatic webhook certificate and CA updates.
  * Ensured the operator’s own namespace remains monitored for webhook-related resources.
  * Automatically skips these permissions when cert-manager manages certificates or the webhook is disabled.

* **Tests**
  * Added coverage for namespace, webhook, and cert-manager configuration combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->