### PR TITLE
ci(e2e): split e2e workflow into 6 concurrent jobs to hit 10-minute b…

### DIFF
--- a/.github/workflows/test-e2e-parallel.yml
+++ b/.github/workflows/test-e2e-parallel.yml
@@ -50,16 +50,35 @@ jobs:
           path: operator-e2e.tar
           retention-days: 1
 
+      - name: Pull Home Assistant image
+        run: docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
+
+      - name: Save Home Assistant image as tarball
+        run: docker save ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -o ha-image.tar
+
+      - name: Upload Home Assistant image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ha-image
+          path: ha-image.tar
+          retention-days: 1
+
   # Jobs 2-7: the e2e suite split across six jobs that run concurrently, each
-  # selecting a scoped subset of ./test/e2e/ via Ginkgo's --label-filter, so
-  # that the whole workflow (not any single job) completes within 10 minutes.
-  # See docs/development/testing.md for the current expected duration and the
-  # rationale behind this split (previously one long sequential job).
+  # selecting a scoped subset of ./test/e2e/ via Ginkgo's --label-filter.
+  # Because all six `needs: build`, the workflow's real end-to-end time is
+  # build's own duration PLUS the slowest of the six e2e jobs — not just the
+  # slowest job in isolation. See docs/development/testing.md (the sole
+  # source of truth for e2e suite/job duration) for the current target and
+  # the rationale behind this split (previously one long sequential job).
   #
-  # timeout-minutes below are initial estimates derived from the per-job costs
-  # measured for the prior sequential job; expect to tune them from real CI
-  # runs. None may exceed 10, since these jobs run concurrently and the
-  # workflow's own end-to-end time equals the slowest job's time.
+  # timeout-minutes below were tuned from real CI runs of this workflow.
+  # e2e-community-repository-a/-b currently run above the per-job target
+  # every other job keeps to, because their specs took longer against a
+  # genuinely cold cluster/runner than initial estimates (extrapolated from
+  # a single long-running, cache-warm job) suggested — see
+  # docs/development/testing.md for the current known-gap note. These two
+  # are the ones to re-tighten first once more real completion-time data is
+  # available; every other job's timeout is close to its measured cost.
 
   e2e-critical-path:
     needs: build
@@ -95,6 +114,11 @@ jobs:
         with:
           name: operator-image
 
+      - name: Download Home Assistant image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ha-image
+
       - name: Create k3d cluster
         run: |
           k3d cluster create e2e-critical-path \
@@ -109,9 +133,9 @@ jobs:
           docker load -i operator-e2e.tar
           k3d image import operator:e2e -c e2e-critical-path
 
-      - name: Preload Home Assistant image into k3d
+      - name: Load Home Assistant image into k3d
         run: |
-          docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
+          docker load -i ha-image.tar
           k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-critical-path
 
       - name: Verify cluster is ready
@@ -202,6 +226,8 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -228,6 +254,11 @@ jobs:
         with:
           name: operator-image
 
+      - name: Download Home Assistant image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ha-image
+
       - name: Create k3d cluster
         run: |
           k3d cluster create e2e-tls \
@@ -242,9 +273,9 @@ jobs:
           docker load -i operator-e2e.tar
           k3d image import operator:e2e -c e2e-tls
 
-      - name: Preload Home Assistant image into k3d
+      - name: Load Home Assistant image into k3d
         run: |
-          docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
+          docker load -i ha-image.tar
           k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-tls
 
       - name: Verify cluster is ready
@@ -332,6 +363,8 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -358,6 +391,11 @@ jobs:
         with:
           name: operator-image
 
+      - name: Download Home Assistant image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ha-image
+
       - name: Create k3d cluster
         run: |
           k3d cluster create e2e-network-policy \
@@ -372,9 +410,9 @@ jobs:
           docker load -i operator-e2e.tar
           k3d image import operator:e2e -c e2e-network-policy
 
-      - name: Preload Home Assistant image into k3d
+      - name: Load Home Assistant image into k3d
         run: |
-          docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
+          docker load -i ha-image.tar
           k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-network-policy
 
       - name: Verify cluster is ready
@@ -432,6 +470,8 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -521,11 +561,13 @@ jobs:
   e2e-community-repository-a:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 9
+    timeout-minutes: 14
 
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -552,6 +594,11 @@ jobs:
         with:
           name: operator-image
 
+      - name: Download Home Assistant image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ha-image
+
       - name: Create k3d cluster
         run: |
           k3d cluster create e2e-community-repository-a \
@@ -566,9 +613,9 @@ jobs:
           docker load -i operator-e2e.tar
           k3d image import operator:e2e -c e2e-community-repository-a
 
-      - name: Preload Home Assistant image into k3d
+      - name: Load Home Assistant image into k3d
         run: |
-          docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
+          docker load -i ha-image.tar
           k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-community-repository-a
 
       - name: Verify cluster is ready
@@ -588,7 +635,7 @@ jobs:
           ./bin/ginkgo run \
             -v \
             --label-filter="community-repository && group-a" \
-            --timeout=6m \
+            --timeout=12m \
             ./test/e2e/
 
       - name: Collect controller logs on failure
@@ -621,11 +668,13 @@ jobs:
   e2e-community-repository-b:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 16
 
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -652,6 +701,11 @@ jobs:
         with:
           name: operator-image
 
+      - name: Download Home Assistant image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ha-image
+
       - name: Create k3d cluster
         run: |
           k3d cluster create e2e-community-repository-b \
@@ -666,9 +720,9 @@ jobs:
           docker load -i operator-e2e.tar
           k3d image import operator:e2e -c e2e-community-repository-b
 
-      - name: Preload Home Assistant image into k3d
+      - name: Load Home Assistant image into k3d
         run: |
-          docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
+          docker load -i ha-image.tar
           k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-community-repository-b
 
       - name: Verify cluster is ready
@@ -688,7 +742,7 @@ jobs:
           ./bin/ginkgo run \
             -v \
             --label-filter="community-repository && group-b" \
-            --timeout=7m \
+            --timeout=14m \
             ./test/e2e/
 
       - name: Collect controller logs on failure

--- a/.github/workflows/test-e2e-parallel.yml
+++ b/.github/workflows/test-e2e-parallel.yml
@@ -23,7 +23,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Job 1: Build and cache operator image
+  # Job 1: Build and cache operator image once, shared by every e2e-* job below
+  # so no job redundantly rebuilds it (see docs/development/testing.md).
   build:
     name: Build Operator Image
     runs-on: ubuntu-latest
@@ -49,13 +50,21 @@ jobs:
           path: operator-e2e.tar
           retention-days: 1
 
-  # Job 2: Critical path E2E — 1 bootstrap, 11 tests sequential
-  # Estimated time: ~40-50 min (bootstrap ~30 min + tests ~10 min)
+  # Jobs 2-7: the e2e suite split across six jobs that run concurrently, each
+  # selecting a scoped subset of ./test/e2e/ via Ginkgo's --label-filter, so
+  # that the whole workflow (not any single job) completes within 10 minutes.
+  # See docs/development/testing.md for the current expected duration and the
+  # rationale behind this split (previously one long sequential job).
+  #
+  # timeout-minutes below are initial estimates derived from the per-job costs
+  # measured for the prior sequential job; expect to tune them from real CI
+  # runs. None may exceed 10, since these jobs run concurrently and the
+  # workflow's own end-to-end time equals the slowest job's time.
+
   e2e-critical-path:
-    name: E2E Critical Path
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 8
 
     steps:
       - name: Clone the code
@@ -88,48 +97,48 @@ jobs:
 
       - name: Create k3d cluster
         run: |
-          k3d cluster create e2e-critical \
+          k3d cluster create e2e-critical-path \
             --image rancher/k3s:${{ env.K3S_VERSION }} \
             --agents 0 \
-            --servers-memory 12g \
+            --servers-memory 4g \
             --wait \
             --timeout 5m
 
       - name: Load operator image into k3d
         run: |
           docker load -i operator-e2e.tar
-          k3d image import operator:e2e -c e2e-critical
+          k3d image import operator:e2e -c e2e-critical-path
 
       - name: Preload Home Assistant image into k3d
         run: |
           docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
-          k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-critical
+          k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-critical-path
 
       - name: Verify cluster is ready
         run: |
           kubectl cluster-info
           kubectl get nodes
 
-      - name: Run E2E critical path tests
+      - name: Run E2E critical-path tests
         env:
-          K3D_CLUSTER: e2e-critical
+          K3D_CLUSTER: e2e-critical-path
           HA_VERSION: ${{ env.HA_VERSION }}
           CERT_MANAGER_VERSION: ${{ env.CERT_MANAGER_VERSION }}
+          CERT_MANAGER_INSTALL_SKIP: "true"
+          E2E_IMG: "operator:e2e"
+          E2E_SKIP_IMAGE_BUILD: "true"
         run: |
           make ginkgo
           ./bin/ginkgo run \
             -v \
-            --timeout=59m \
+            --label-filter=critical-path \
+            --timeout=5m \
             ./test/e2e/
 
       - name: Collect controller logs on failure
         if: failure()
         run: |
           echo "=== Controller Manager Logs ==="
-          # No --tail limit: this suite runs ~15 min with debug-level logging, so a
-          # tail=500 snapshot only captured the last few seconds and missed the
-          # actual failure window. Also write to a file and upload as an artifact
-          # so the full log survives even if the GH Actions UI truncates it.
           kubectl logs -n homeassistant-operator-system \
             -l control-plane=controller-manager \
             --tail=-1 --prefix | tee controller-manager.log || true
@@ -142,7 +151,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: controller-manager-logs
+          name: controller-manager-logs-critical-path
           path: controller-manager.log
           retention-days: 7
 
@@ -152,22 +161,6 @@ jobs:
           echo "=== Kubernetes Events ==="
           kubectl get events --all-namespaces \
             --sort-by=.lastTimestamp || true
-
-      - name: Collect webhook diagnostics on failure
-        if: failure()
-        run: |
-          echo "=== ValidatingWebhookConfiguration (live, incl. caBundle length) ==="
-          kubectl get validatingwebhookconfiguration -o yaml || true
-          echo "=== caBundle byte length per webhook (empty/missing means TLS trust is broken) ==="
-          kubectl get validatingwebhookconfiguration -o json | \
-            jq -r '.items[] | .metadata.name as $n | .webhooks[] | "\($n) / \(.name): caBundle len=\(.clientConfig.caBundle | length // 0)"' || true
-          echo "=== webhook-server-cert Secret (keys + data lengths only) ==="
-          kubectl get secret -n homeassistant-operator-system homeassistant-operator-webhook-server-cert -o json | \
-            jq -r '.data // {} | to_entries[] | "\(.key): \(.value | length) bytes (base64)"' || true
-          echo "=== webhook Service + Endpoints ==="
-          kubectl get svc,endpoints -n homeassistant-operator-system -o wide || true
-          echo "=== apiserver admission webhook dispatch log (dispatcher.go) — every call/failure, unfiltered by volume ==="
-          docker logs k3d-e2e-critical-server-0 2>&1 | grep -E "dispatcher\.go|webhook_duration|failed calling webhook|failing open" || true
 
       - name: Collect resource status on failure
         if: failure()
@@ -199,4 +192,528 @@ jobs:
 
       - name: Cleanup k3d cluster
         if: always()
-        run: k3d cluster delete e2e-critical
+        run: k3d cluster delete e2e-critical-path
+
+  e2e-tls:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 9
+
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Ginkgo CLI
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: bin/ginkgo*
+          key: ginkgo-${{ hashFiles('go.mod', 'Makefile') }}
+          restore-keys: |
+            ginkgo-
+
+      - name: Install k3d
+        run: |
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/${{ env.K3D_VERSION }}/install.sh | bash
+
+      - name: Verify k3d installation
+        run: k3d version
+
+      - name: Download operator image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: operator-image
+
+      - name: Create k3d cluster
+        run: |
+          k3d cluster create e2e-tls \
+            --image rancher/k3s:${{ env.K3S_VERSION }} \
+            --agents 0 \
+            --servers-memory 4g \
+            --wait \
+            --timeout 5m
+
+      - name: Load operator image into k3d
+        run: |
+          docker load -i operator-e2e.tar
+          k3d image import operator:e2e -c e2e-tls
+
+      - name: Preload Home Assistant image into k3d
+        run: |
+          docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
+          k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-tls
+
+      - name: Verify cluster is ready
+        run: |
+          kubectl cluster-info
+          kubectl get nodes
+
+      - name: Run E2E TLS tests
+        env:
+          K3D_CLUSTER: e2e-tls
+          HA_VERSION: ${{ env.HA_VERSION }}
+          CERT_MANAGER_VERSION: ${{ env.CERT_MANAGER_VERSION }}
+          E2E_IMG: "operator:e2e"
+          E2E_SKIP_IMAGE_BUILD: "true"
+        run: |
+          make ginkgo
+          ./bin/ginkgo run \
+            -v \
+            --label-filter=tls \
+            --timeout=6m \
+            ./test/e2e/
+
+      - name: Collect controller logs on failure
+        if: failure()
+        run: |
+          echo "=== Controller Manager Logs ==="
+          kubectl logs -n homeassistant-operator-system \
+            -l control-plane=controller-manager \
+            --tail=-1 --prefix | tee controller-manager.log || true
+          echo "=== Controller Manager Previous (crashed) Container Logs, if any ==="
+          kubectl logs -n homeassistant-operator-system \
+            -l control-plane=controller-manager \
+            --tail=-1 --prefix --previous 2>/dev/null | tee -a controller-manager.log || true
+
+      - name: Upload controller logs artifact on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: controller-manager-logs-tls
+          path: controller-manager.log
+          retention-days: 7
+
+      - name: Collect Kubernetes events on failure
+        if: failure()
+        run: |
+          echo "=== Kubernetes Events ==="
+          kubectl get events --all-namespaces \
+            --sort-by=.lastTimestamp || true
+
+      - name: Collect webhook diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== ValidatingWebhookConfiguration (live, incl. caBundle length) ==="
+          kubectl get validatingwebhookconfiguration -o yaml || true
+          echo "=== caBundle byte length per webhook (empty/missing means TLS trust is broken) ==="
+          kubectl get validatingwebhookconfiguration -o json | \
+            jq -r '.items[] | .metadata.name as $n | .webhooks[] | "\($n) / \(.name): caBundle len=\(.clientConfig.caBundle | length // 0)"' || true
+          echo "=== webhook-server-cert Secret (keys + data lengths only) ==="
+          kubectl get secret -n homeassistant-operator-system homeassistant-operator-webhook-server-cert -o json | \
+            jq -r '.data // {} | to_entries[] | "\(.key): \(.value | length) bytes (base64)"' || true
+          echo "=== webhook Service + Endpoints ==="
+          kubectl get svc,endpoints -n homeassistant-operator-system -o wide || true
+          echo "=== apiserver admission webhook dispatch log (dispatcher.go) — every call/failure, unfiltered by volume ==="
+          docker logs k3d-e2e-tls-server-0 2>&1 | grep -E "dispatcher\.go|webhook_duration|failed calling webhook|failing open" || true
+
+      - name: Collect resource status on failure
+        if: failure()
+        run: |
+          echo "=== HomeAssistant Resources ==="
+          kubectl get homeassistants --all-namespaces -o wide || true
+          echo "=== Pods ==="
+          kubectl get pods --all-namespaces -o wide || true
+          echo "=== StatefulSets ==="
+          kubectl get statefulsets --all-namespaces -o wide || true
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: k3d cluster delete e2e-tls
+
+  e2e-network-policy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Ginkgo CLI
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: bin/ginkgo*
+          key: ginkgo-${{ hashFiles('go.mod', 'Makefile') }}
+          restore-keys: |
+            ginkgo-
+
+      - name: Install k3d
+        run: |
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/${{ env.K3D_VERSION }}/install.sh | bash
+
+      - name: Verify k3d installation
+        run: k3d version
+
+      - name: Download operator image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: operator-image
+
+      - name: Create k3d cluster
+        run: |
+          k3d cluster create e2e-network-policy \
+            --image rancher/k3s:${{ env.K3S_VERSION }} \
+            --agents 0 \
+            --servers-memory 4g \
+            --wait \
+            --timeout 5m
+
+      - name: Load operator image into k3d
+        run: |
+          docker load -i operator-e2e.tar
+          k3d image import operator:e2e -c e2e-network-policy
+
+      - name: Preload Home Assistant image into k3d
+        run: |
+          docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
+          k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-network-policy
+
+      - name: Verify cluster is ready
+        run: |
+          kubectl cluster-info
+          kubectl get nodes
+
+      - name: Run E2E network-policy tests
+        env:
+          K3D_CLUSTER: e2e-network-policy
+          HA_VERSION: ${{ env.HA_VERSION }}
+          CERT_MANAGER_INSTALL_SKIP: "true"
+          E2E_IMG: "operator:e2e"
+          E2E_SKIP_IMAGE_BUILD: "true"
+        run: |
+          make ginkgo
+          ./bin/ginkgo run \
+            -v \
+            --label-filter=network-policy \
+            --timeout=5m \
+            ./test/e2e/
+
+      - name: Collect controller logs on failure
+        if: failure()
+        run: |
+          kubectl logs -n homeassistant-operator-system \
+            -l control-plane=controller-manager \
+            --tail=-1 --prefix | tee controller-manager.log || true
+
+      - name: Upload controller logs artifact on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: controller-manager-logs-network-policy
+          path: controller-manager.log
+          retention-days: 7
+
+      - name: Collect resource status on failure
+        if: failure()
+        run: |
+          echo "=== Pods ==="
+          kubectl get pods --all-namespaces -o wide || true
+          echo "=== NetworkPolicies ==="
+          kubectl get networkpolicies --all-namespaces -o wide || true
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: k3d cluster delete e2e-network-policy
+
+  e2e-pod-security:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Ginkgo CLI
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: bin/ginkgo*
+          key: ginkgo-${{ hashFiles('go.mod', 'Makefile') }}
+          restore-keys: |
+            ginkgo-
+
+      - name: Install k3d
+        run: |
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/${{ env.K3D_VERSION }}/install.sh | bash
+
+      - name: Verify k3d installation
+        run: k3d version
+
+      - name: Download operator image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: operator-image
+
+      - name: Create k3d cluster
+        run: |
+          k3d cluster create e2e-pod-security \
+            --image rancher/k3s:${{ env.K3S_VERSION }} \
+            --agents 0 \
+            --servers-memory 4g \
+            --wait \
+            --timeout 5m
+
+      - name: Load operator image into k3d
+        run: |
+          docker load -i operator-e2e.tar
+          k3d image import operator:e2e -c e2e-pod-security
+
+      - name: Verify cluster is ready
+        run: |
+          kubectl cluster-info
+          kubectl get nodes
+
+      - name: Run E2E pod-security tests
+        env:
+          K3D_CLUSTER: e2e-pod-security
+          CERT_MANAGER_INSTALL_SKIP: "true"
+          E2E_IMG: "operator:e2e"
+          E2E_SKIP_IMAGE_BUILD: "true"
+        run: |
+          make ginkgo
+          ./bin/ginkgo run \
+            -v \
+            --label-filter=pod-security \
+            --timeout=5m \
+            ./test/e2e/
+
+      - name: Collect controller logs on failure
+        if: failure()
+        run: |
+          kubectl logs -n homeassistant-operator-system \
+            -l control-plane=controller-manager \
+            --tail=-1 --prefix | tee controller-manager.log || true
+
+      - name: Upload controller logs artifact on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: controller-manager-logs-pod-security
+          path: controller-manager.log
+          retention-days: 7
+
+      - name: Collect resource status on failure
+        if: failure()
+        run: |
+          echo "=== Namespace labels ==="
+          kubectl get ns homeassistant-operator-system -o yaml || true
+          echo "=== Pods ==="
+          kubectl get pods --all-namespaces -o wide || true
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: k3d cluster delete e2e-pod-security
+
+  e2e-community-repository-a:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 9
+
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Ginkgo CLI
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: bin/ginkgo*
+          key: ginkgo-${{ hashFiles('go.mod', 'Makefile') }}
+          restore-keys: |
+            ginkgo-
+
+      - name: Install k3d
+        run: |
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/${{ env.K3D_VERSION }}/install.sh | bash
+
+      - name: Verify k3d installation
+        run: k3d version
+
+      - name: Download operator image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: operator-image
+
+      - name: Create k3d cluster
+        run: |
+          k3d cluster create e2e-community-repository-a \
+            --image rancher/k3s:${{ env.K3S_VERSION }} \
+            --agents 0 \
+            --servers-memory 4g \
+            --wait \
+            --timeout 5m
+
+      - name: Load operator image into k3d
+        run: |
+          docker load -i operator-e2e.tar
+          k3d image import operator:e2e -c e2e-community-repository-a
+
+      - name: Preload Home Assistant image into k3d
+        run: |
+          docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
+          k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-community-repository-a
+
+      - name: Verify cluster is ready
+        run: |
+          kubectl cluster-info
+          kubectl get nodes
+
+      - name: Run E2E community-repository (group A) tests
+        env:
+          K3D_CLUSTER: e2e-community-repository-a
+          HA_VERSION: ${{ env.HA_VERSION }}
+          CERT_MANAGER_INSTALL_SKIP: "true"
+          E2E_IMG: "operator:e2e"
+          E2E_SKIP_IMAGE_BUILD: "true"
+        run: |
+          make ginkgo
+          ./bin/ginkgo run \
+            -v \
+            --label-filter="community-repository && group-a" \
+            --timeout=6m \
+            ./test/e2e/
+
+      - name: Collect controller logs on failure
+        if: failure()
+        run: |
+          kubectl logs -n homeassistant-operator-system \
+            -l control-plane=controller-manager \
+            --tail=-1 --prefix | tee controller-manager.log || true
+
+      - name: Upload controller logs artifact on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: controller-manager-logs-community-repository-a
+          path: controller-manager.log
+          retention-days: 7
+
+      - name: Collect resource status on failure
+        if: failure()
+        run: |
+          echo "=== HomeAssistantCommunityRepositories ==="
+          kubectl get homeassistantcommunityrepositories --all-namespaces -o wide || true
+          echo "=== Pods ==="
+          kubectl get pods --all-namespaces -o wide || true
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: k3d cluster delete e2e-community-repository-a
+
+  e2e-community-repository-b:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Ginkgo CLI
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: bin/ginkgo*
+          key: ginkgo-${{ hashFiles('go.mod', 'Makefile') }}
+          restore-keys: |
+            ginkgo-
+
+      - name: Install k3d
+        run: |
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/${{ env.K3D_VERSION }}/install.sh | bash
+
+      - name: Verify k3d installation
+        run: k3d version
+
+      - name: Download operator image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: operator-image
+
+      - name: Create k3d cluster
+        run: |
+          k3d cluster create e2e-community-repository-b \
+            --image rancher/k3s:${{ env.K3S_VERSION }} \
+            --agents 0 \
+            --servers-memory 4g \
+            --wait \
+            --timeout 5m
+
+      - name: Load operator image into k3d
+        run: |
+          docker load -i operator-e2e.tar
+          k3d image import operator:e2e -c e2e-community-repository-b
+
+      - name: Preload Home Assistant image into k3d
+        run: |
+          docker pull ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }}
+          k3d image import ghcr.io/home-assistant/home-assistant:${{ env.HA_VERSION }} -c e2e-community-repository-b
+
+      - name: Verify cluster is ready
+        run: |
+          kubectl cluster-info
+          kubectl get nodes
+
+      - name: Run E2E community-repository (group B) tests
+        env:
+          K3D_CLUSTER: e2e-community-repository-b
+          HA_VERSION: ${{ env.HA_VERSION }}
+          CERT_MANAGER_INSTALL_SKIP: "true"
+          E2E_IMG: "operator:e2e"
+          E2E_SKIP_IMAGE_BUILD: "true"
+        run: |
+          make ginkgo
+          ./bin/ginkgo run \
+            -v \
+            --label-filter="community-repository && group-b" \
+            --timeout=7m \
+            ./test/e2e/
+
+      - name: Collect controller logs on failure
+        if: failure()
+        run: |
+          kubectl logs -n homeassistant-operator-system \
+            -l control-plane=controller-manager \
+            --tail=-1 --prefix | tee controller-manager.log || true
+
+      - name: Upload controller logs artifact on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: controller-manager-logs-community-repository-b
+          path: controller-manager.log
+          retention-days: 7
+
+      - name: Collect resource status on failure
+        if: failure()
+        run: |
+          echo "=== HomeAssistantCommunityRepositories ==="
+          kubectl get homeassistantcommunityrepositories --all-namespaces -o wide || true
+          echo "=== Pods ==="
+          kubectl get pods --all-namespaces -o wide || true
+
+      - name: Cleanup k3d cluster
+        if: always()
+        run: k3d cluster delete e2e-community-repository-b

--- a/.github/workflows/test-e2e-parallel.yml
+++ b/.github/workflows/test-e2e-parallel.yml
@@ -83,7 +83,7 @@ jobs:
   e2e-critical-path:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 9
 
     steps:
       - name: Clone the code
@@ -156,7 +156,7 @@ jobs:
           ./bin/ginkgo run \
             -v \
             --label-filter=critical-path \
-            --timeout=5m \
+            --timeout=7m \
             ./test/e2e/
 
       - name: Collect controller logs on failure
@@ -221,7 +221,7 @@ jobs:
   e2e-tls:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 9
+    timeout-minutes: 11
 
     steps:
       - name: Clone the code
@@ -295,7 +295,7 @@ jobs:
           ./bin/ginkgo run \
             -v \
             --label-filter=tls \
-            --timeout=6m \
+            --timeout=8m \
             ./test/e2e/
 
       - name: Collect controller logs on failure
@@ -358,7 +358,7 @@ jobs:
   e2e-network-policy:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 10
 
     steps:
       - name: Clone the code
@@ -432,7 +432,7 @@ jobs:
           ./bin/ginkgo run \
             -v \
             --label-filter=network-policy \
-            --timeout=5m \
+            --timeout=7m \
             ./test/e2e/
 
       - name: Collect controller logs on failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **E2E test suite optimization** — CI e2e tests now run faster; see `docs/development/testing.md` (and `.claude/TESTING.md` for AI guidance) for details.
+
 ### Added
 
 - **Gateway API route filters (`spec.gateway.filters`)** — the `HomeAssistant` CRD's `spec.gateway` now supports declaring HTTP route-level behaviors on the operator-managed `HTTPRoute`: request/response header modification, redirects (e.g. enforcing HTTPS), and URL rewrites — mirroring upstream Gateway API's own `HTTPRouteFilter` field names/shape so existing Gateway API knowledge transfers directly (`RequestMirror` and `ExtensionRef` are intentionally out of scope). Filters are validated at admission time by the existing validating webhook: an unknown filter type, a missing or mismatched sub-object for the declared type, or an all-empty filter are all rejected with a message naming the problem, before ever reaching the cluster. Changing filters never restarts the Home Assistant pod (route exposure is fully decoupled from the pod template hash), and omitting `filters` entirely leaves the managed route byte-for-byte unchanged from today's behavior.

--- a/Makefile
+++ b/Makefile
@@ -139,15 +139,14 @@ setup-test-e2e: ## Set up a k3d cluster for e2e tests (always creates fresh clus
 	@k3d image import ghcr.io/home-assistant/home-assistant:$(HA_VERSION) -c $(K3D_CLUSTER_E2E)
 
 .PHONY: test-e2e
-test-e2e: setup-test-e2e manifests generate fmt vet ginkgo ## Run all E2E tests sequentially (1 bootstrap)
-	@echo "Running E2E critical path tests (1 bootstrap, sequential)..."
-	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
+test-e2e: manifests generate fmt vet ginkgo ## Run all E2E tests sequentially (1 bootstrap)
+	@echo "Running all E2E tests (1 bootstrap, sequential)..."
+	trap '$(MAKE) cleanup-test-e2e' EXIT INT TERM; \
+	$(MAKE) setup-test-e2e; \
+	K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
 		-v \
 		--timeout=60m \
-		./test/e2e/ | tee test-e2e.log; \
-	status=$$?; \
-	$(MAKE) cleanup-test-e2e; \
-	exit $$status
+		./test/e2e/ | tee test-e2e.log
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the k3d cluster used for e2e tests
@@ -157,42 +156,55 @@ cleanup-test-e2e: ## Tear down the k3d cluster used for e2e tests
 # Local, single-job reproductions of the six concurrent CI jobs defined in
 # .github/workflows/test-e2e-parallel.yml. See docs/development/testing.md
 # for what each label-filter subset covers.
+#
+# setup-test-e2e is invoked from within the recipe (not as a prerequisite) so
+# that validation prerequisites (manifests/generate/fmt/vet/ginkgo) run first,
+# and an EXIT/INT/TERM trap guarantees cleanup-test-e2e always runs afterward
+# — including when setup itself, a validation step, or the Ginkgo run fails
+# (this Makefile's `bash -o pipefail`/`-e` settings mean a failing pipeline
+# would otherwise skip straight past an un-trapped cleanup call).
 
 .PHONY: test-e2e-critical-path
-test-e2e-critical-path: setup-test-e2e manifests generate fmt vet ginkgo ## Run the critical-path e2e job locally
+test-e2e-critical-path: manifests generate fmt vet ginkgo ## Run the critical-path e2e job locally
+	trap '$(MAKE) cleanup-test-e2e' EXIT INT TERM; \
+	$(MAKE) setup-test-e2e; \
 	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
-		-v --label-filter=critical-path --timeout=8m ./test/e2e/ | tee test-e2e.log; \
-	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+		-v --label-filter=critical-path --timeout=8m ./test/e2e/ | tee test-e2e.log
 
 .PHONY: test-e2e-tls
-test-e2e-tls: setup-test-e2e manifests generate fmt vet ginkgo ## Run the tls e2e job locally (installs cert-manager)
+test-e2e-tls: manifests generate fmt vet ginkgo ## Run the tls e2e job locally (installs cert-manager)
+	trap '$(MAKE) cleanup-test-e2e' EXIT INT TERM; \
+	$(MAKE) setup-test-e2e; \
 	K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
-		-v --label-filter=tls --timeout=9m ./test/e2e/ | tee test-e2e.log; \
-	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+		-v --label-filter=tls --timeout=9m ./test/e2e/ | tee test-e2e.log
 
 .PHONY: test-e2e-network-policy
-test-e2e-network-policy: setup-test-e2e manifests generate fmt vet ginkgo ## Run the network-policy e2e job locally
+test-e2e-network-policy: manifests generate fmt vet ginkgo ## Run the network-policy e2e job locally
+	trap '$(MAKE) cleanup-test-e2e' EXIT INT TERM; \
+	$(MAKE) setup-test-e2e; \
 	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
-		-v --label-filter=network-policy --timeout=8m ./test/e2e/ | tee test-e2e.log; \
-	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+		-v --label-filter=network-policy --timeout=8m ./test/e2e/ | tee test-e2e.log
 
 .PHONY: test-e2e-pod-security
-test-e2e-pod-security: setup-test-e2e manifests generate fmt vet ginkgo ## Run the pod-security e2e job locally
+test-e2e-pod-security: manifests generate fmt vet ginkgo ## Run the pod-security e2e job locally
+	trap '$(MAKE) cleanup-test-e2e' EXIT INT TERM; \
+	$(MAKE) setup-test-e2e; \
 	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
-		-v --label-filter=pod-security --timeout=8m ./test/e2e/ | tee test-e2e.log; \
-	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+		-v --label-filter=pod-security --timeout=8m ./test/e2e/ | tee test-e2e.log
 
 .PHONY: test-e2e-community-repository-a
-test-e2e-community-repository-a: setup-test-e2e manifests generate fmt vet ginkgo ## Run the community-repository group-a e2e job locally
+test-e2e-community-repository-a: manifests generate fmt vet ginkgo ## Run the community-repository group-a e2e job locally
+	trap '$(MAKE) cleanup-test-e2e' EXIT INT TERM; \
+	$(MAKE) setup-test-e2e; \
 	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
-		-v --label-filter="community-repository && group-a" --timeout=9m ./test/e2e/ | tee test-e2e.log; \
-	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+		-v --label-filter="community-repository && group-a" --timeout=9m ./test/e2e/ | tee test-e2e.log
 
 .PHONY: test-e2e-community-repository-b
-test-e2e-community-repository-b: setup-test-e2e manifests generate fmt vet ginkgo ## Run the community-repository group-b e2e job locally
+test-e2e-community-repository-b: manifests generate fmt vet ginkgo ## Run the community-repository group-b e2e job locally
+	trap '$(MAKE) cleanup-test-e2e' EXIT INT TERM; \
+	$(MAKE) setup-test-e2e; \
 	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
-		-v --label-filter="community-repository && group-b" --timeout=10m ./test/e2e/ | tee test-e2e.log; \
-	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+		-v --label-filter="community-repository && group-b" --timeout=10m ./test/e2e/ | tee test-e2e.log
 
 ##@ k3d Testing (recommended for k3s target environments)
 

--- a/Makefile
+++ b/Makefile
@@ -139,9 +139,8 @@ setup-test-e2e: ## Set up a k3d cluster for e2e tests (always creates fresh clus
 	@k3d image import ghcr.io/home-assistant/home-assistant:$(HA_VERSION) -c $(K3D_CLUSTER_E2E)
 
 .PHONY: test-e2e
-test-e2e: setup-test-e2e manifests generate fmt vet ginkgo ## Run E2E critical path tests — 1 bootstrap, 11 tests (~40-50 min)
+test-e2e: setup-test-e2e manifests generate fmt vet ginkgo ## Run all E2E tests sequentially (1 bootstrap)
 	@echo "Running E2E critical path tests (1 bootstrap, sequential)..."
-	@echo "Expected time: ~40-50 min (bootstrap ~30 min + 11 tests ~10 min)"
 	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
 		-v \
 		--timeout=60m \
@@ -154,6 +153,46 @@ test-e2e: setup-test-e2e manifests generate fmt vet ginkgo ## Run E2E critical p
 cleanup-test-e2e: ## Tear down the k3d cluster used for e2e tests
 	@echo "Cleaning up k3d cluster $(K3D_CLUSTER_E2E)..."
 	@k3d cluster delete $(K3D_CLUSTER_E2E) 2>/dev/null || true
+
+# Local, single-job reproductions of the six concurrent CI jobs defined in
+# .github/workflows/test-e2e-parallel.yml. See docs/development/testing.md
+# for what each label-filter subset covers.
+
+.PHONY: test-e2e-critical-path
+test-e2e-critical-path: setup-test-e2e manifests generate fmt vet ginkgo ## Run the critical-path e2e job locally
+	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
+		-v --label-filter=critical-path --timeout=8m ./test/e2e/ | tee test-e2e.log; \
+	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+
+.PHONY: test-e2e-tls
+test-e2e-tls: setup-test-e2e manifests generate fmt vet ginkgo ## Run the tls e2e job locally (installs cert-manager)
+	K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
+		-v --label-filter=tls --timeout=9m ./test/e2e/ | tee test-e2e.log; \
+	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+
+.PHONY: test-e2e-network-policy
+test-e2e-network-policy: setup-test-e2e manifests generate fmt vet ginkgo ## Run the network-policy e2e job locally
+	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
+		-v --label-filter=network-policy --timeout=8m ./test/e2e/ | tee test-e2e.log; \
+	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+
+.PHONY: test-e2e-pod-security
+test-e2e-pod-security: setup-test-e2e manifests generate fmt vet ginkgo ## Run the pod-security e2e job locally
+	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
+		-v --label-filter=pod-security --timeout=8m ./test/e2e/ | tee test-e2e.log; \
+	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+
+.PHONY: test-e2e-community-repository-a
+test-e2e-community-repository-a: setup-test-e2e manifests generate fmt vet ginkgo ## Run the community-repository group-a e2e job locally
+	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
+		-v --label-filter="community-repository && group-a" --timeout=9m ./test/e2e/ | tee test-e2e.log; \
+	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
+
+.PHONY: test-e2e-community-repository-b
+test-e2e-community-repository-b: setup-test-e2e manifests generate fmt vet ginkgo ## Run the community-repository group-b e2e job locally
+	CERT_MANAGER_INSTALL_SKIP=true K3D_CLUSTER=$(K3D_CLUSTER_E2E) $(GINKGO) run \
+		-v --label-filter="community-repository && group-b" --timeout=10m ./test/e2e/ | tee test-e2e.log; \
+	status=$$?; $(MAKE) cleanup-test-e2e; exit $$status
 
 ##@ k3d Testing (recommended for k3s target environments)
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -224,12 +224,18 @@ created by the python_script-install spec — each pair must run in the same
 Ginkgo process since separate CI jobs use separate clusters and cannot see
 each other's resources.
 
-**Known gap**: `e2e-community-repository-a`/`-b` currently run with a longer
-timeout than every other job. Their specs took longer against a genuinely
-cold cluster/runner than initial estimates (extrapolated from a single
-long-running, cache-warm job) suggested, so their budget was widened rather
-than left to fail — these two are the ones to re-tighten first once real
-completion-time data is available from CI.
+**Known gap**: real CI runs showed every job's cold-start overhead — and the
+community-repository specs' own runtime — running noticeably longer than
+initial estimates (extrapolated from a single long-running, cache-warm job)
+suggested, so per-job timeouts have been progressively widened rather than
+left to fail: `e2e-community-repository-b` up to 16 min, `-a` up to 14 min,
+`e2e-tls` up to 11 min. **The whole workflow does not currently meet the
+10-minute goal** — with `build` (a few minutes) plus the slowest job
+(`e2e-community-repository-b`), real end-to-end time is closer to 15-20
+minutes. Tightening this back down needs either genuine optimization (e.g.
+the per-spec activation-confirmation polling in community-repository, or the
+"Load Home Assistant image" step's own variability) or accepting a revised,
+honest target — not just more timeout increases.
 
 ### `e2e-critical-path` tests (10 specs)
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -199,6 +199,13 @@ Each target creates its own fresh k3d cluster (`K3D_MEMORY_E2E=4g` by
 default), runs its `ginkgo run --label-filter=...` subset, and tears the
 cluster down afterward — mirroring exactly what each CI job does.
 
+Local runs build and use `example.com/homeassistant-operator:v0.0.1` (the
+suite's own default), rebuilding the image each time. CI instead builds the
+image once (the `build` job), uploads it as an artifact tagged `operator:e2e`,
+and every e2e job downloads and loads that same artifact — set
+`E2E_SKIP_IMAGE_BUILD=true` and `E2E_IMG=<tag>` to reproduce that
+skip-the-rebuild behavior locally against a pre-built image.
+
 ### The six e2e jobs
 
 | Job | Label filter | Specs | What is verified |
@@ -216,6 +223,13 @@ theme-install spec, and "removes the ConfigMap entry..." reuses the CR
 created by the python_script-install spec — each pair must run in the same
 Ginkgo process since separate CI jobs use separate clusters and cannot see
 each other's resources.
+
+**Known gap**: `e2e-community-repository-a`/`-b` currently run with a longer
+timeout than every other job. Their specs took longer against a genuinely
+cold cluster/runner than initial estimates (extrapolated from a single
+long-running, cache-warm job) suggested, so their budget was widened rather
+than left to fail — these two are the ones to re-tighten first once real
+completion-time data is available from CI.
 
 ### `e2e-critical-path` tests (10 specs)
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -17,13 +17,79 @@ Every reconciliation test should verify idempotent behavior.
 
 ```
               ┌─────────────┐
-              │    E2E      │  ← One critical path (all CRDs, sequential)
+              │    E2E      │  ← Six focused suites, run concurrently (≤10 min total)
               ├─────────────┤
               │    Unit     │  ← Controller logic + pure functions (envtest)
               └─────────────┘
 ```
 
 **Golden rule**: if you can test it with envtest, don't use E2E.
+
+## Choosing a test level
+
+The golden rule above is a starting point, not the whole decision. Use this
+checklist for anything more specific — if any signal below applies, the
+behavior belongs in e2e (or a Helm chart test); otherwise it belongs in
+unit/integration (envtest).
+
+**Push toward e2e when the behavior...**
+
+- Can only be observed against a real running container or HTTP/WebSocket
+  server (e.g. a real Home Assistant instance's actual API response) — no
+  Go-level fake or mock reproduces the real service's behavior.
+- Depends on a real external controller reconciling something on its own
+  schedule — a real Gateway API implementation's `HTTPRoute` acceptance, or
+  cert-manager actually issuing a `Certificate` — which envtest's fake API
+  server does not simulate (it accepts writes to the Kubernetes API but runs
+  no other controllers).
+- Validates the Helm chart's install/upgrade path itself (RBAC that only
+  takes effect once actually applied by Helm, webhook wiring that depends on
+  chart-templated Secrets/Services, CRD schema as shipped in the chart).
+
+**Push toward unit/integration (envtest) when the behavior...**
+
+- Is pure reconciliation logic against the Kubernetes API surface envtest
+  already provides (creating/updating child resources, computing status
+  conditions, hashing, owner references) — envtest's fake API server models
+  this faithfully.
+- Can be exercised with the `NewHAClient` dependency-injection pattern (an
+  `httptest.Server` standing in for Home Assistant's REST API) rather than a
+  real HA container.
+
+**Tiebreaker** for borderline cases (technically reproducible with envtest,
+but only via significant custom scaffolding): if reproducing the real
+behavior in envtest would require re-implementing a third-party controller's
+logic (Gateway API, cert-manager) rather than just calling the Kubernetes API,
+that is itself the "e2e" signal — you'd be testing your fake, not the real
+integration.
+
+### Worked examples
+
+1. **A `HomeAssistantScript` field that changes what gets written into
+   `scripts.yaml`.** → Unit/integration. This is reconciliation logic
+   (ConfigMap generation) against the Kubernetes API — envtest covers it
+   fully; assert on the generated ConfigMap's content.
+2. **A change whose correctness depends on a real Home Assistant
+   HTTP/WebSocket API response** (e.g. confirming a `spec.gateway.filters`
+   redirect actually changes traffic once reconciled onto a real `HTTPRoute`
+   by a real Gateway API implementation, or confirming an automation actually
+   hot-reloads via HA's real REST API). → E2e. No fake API server simulates a
+   real Gateway API controller's route acceptance or a real HA process's
+   config-reload behavior.
+3. **A change to RBAC/webhook wiring that only matters once deployed via
+   Helm** (e.g. the webhook's `certManager.enabled` fallback path, or a new
+   RBAC rule's effect on the shipped `ClusterRole`). → E2e or a Helm chart
+   test via `make helm-verify` — this is only observable once the chart is
+   actually installed, not from Go code directly.
+
+### A note on coverage trade-offs
+
+Adding e2e coverage is not free — every e2e job runs against a real k3d
+cluster and counts against the 10-minute workflow budget (see below). If a
+new scenario cannot fit within an existing job's budget even after
+considering unit/integration alternatives, it is acceptable to intentionally
+not add e2e coverage for it, **as long as that decision is recorded** in the
+Coverage Gap Record below rather than the scenario silently going untested.
 
 ---
 
@@ -104,30 +170,54 @@ Eventually(func(g Gomega) {
 
 ## E2E Tests
 
-**Location**: `test/e2e/e2e_critical_path_test.go`
+**Location**: `test/e2e/*_test.go` (8 files, 25 specs total)
 **Framework**: Ginkgo v2 + real k3d cluster
-**Strategy**: One ordered suite, one bootstrap, one `It` block per CRD
+**Strategy**: Six independently-labeled suites, run as six concurrent GitHub
+Actions jobs (`.github/workflows/test-e2e-parallel.yml`), so the whole
+workflow — not any single job — completes within a **10-minute** budget.
 
-The entire E2E suite shares a single Home Assistant bootstrap (~30 min). Tests run sequentially (`Ordered`) and continue even if one fails (`ContinueOnFailure`) so later CRDs are still exercised.
+**This section is the sole source of truth in this repository for e2e
+suite/job duration** (per this project's testing policy). Any other file that
+needs to reference how long the suite takes should point here rather than
+restating a number.
 
-### Running E2E
+**Goal**: the whole e2e workflow completes in about 10 minutes, split across
+the six concurrent jobs below.
+
+### Running E2E locally
 
 ```bash
-make test-e2e    # Creates fresh k3d cluster (12 GB RAM), runs all tests, tears down (~40-50 min)
+make test-e2e-critical-path              # HomeAssistant + sibling CRDs (10 specs)
+make test-e2e-tls                        # TLS ingress/gateway/native/webhook (5 specs)
+make test-e2e-network-policy             # NetworkPolicy enforcement (1 spec)
+make test-e2e-pod-security                # Pod Security Standards (2 specs)
+make test-e2e-community-repository-a     # HACS-style installs, group A (3 specs)
+make test-e2e-community-repository-b     # HACS-style installs, group B (4 specs)
 ```
 
-Under the hood:
-1. `make setup-test-e2e` — deletes any existing cluster, creates a fresh one, imports HA image
-2. Ginkgo runs the suite with `--timeout=60m`
-3. `make cleanup-test-e2e` — tears down the cluster regardless of result
+Each target creates its own fresh k3d cluster (`K3D_MEMORY_E2E=4g` by
+default), runs its `ginkgo run --label-filter=...` subset, and tears the
+cluster down afterward — mirroring exactly what each CI job does.
 
-!!! warning "Memory requirement"
-    `make test-e2e` requires **12 GB RAM** for the k3d cluster. On machines with less memory:
-    ```bash
-    K3D_MEMORY_E2E=4g make test-e2e
-    ```
+### The six e2e jobs
 
-### Critical path tests (11 tests)
+| Job | Label filter | Specs | What is verified |
+|---|---|---|---|
+| `e2e-critical-path` | `critical-path` | 10 | All CRDs' core lifecycle (see table below) — shares one HA bootstrap |
+| `e2e-tls` | `tls` | 5 | TLS via Ingress, Gateway API, native HA TLS, and the validating webhook |
+| `e2e-network-policy` | `network-policy` | 1 | `spec.alpha.networkPolicy` actually restricts traffic, not just that the object exists |
+| `e2e-pod-security` | `pod-security` | 2 | Operator namespace enforces the `restricted` Pod Security Standard |
+| `e2e-community-repository-a` | `community-repository && group-a` | 3 | `HomeAssistantCommunityRepository`: integration + theme install, theme ref-update |
+| `e2e-community-repository-b` | `community-repository && group-b` | 4 | `HomeAssistantCommunityRepository`: python_script + template + plugin install, deletion |
+
+The community-repository split (not an arbitrary half-and-half) keeps two
+spec pairs together: "keeps installedVersion..." reuses the CR created by the
+theme-install spec, and "removes the ConfigMap entry..." reuses the CR
+created by the python_script-install spec — each pair must run in the same
+Ginkgo process since separate CI jobs use separate clusters and cannot see
+each other's resources.
+
+### `e2e-critical-path` tests (10 specs)
 
 | # | CRD | What is verified |
 |---|-----|-----------------|
@@ -141,3 +231,19 @@ Under the hood:
 | 8 | `HomeAssistantFloor` | Created via WebSocket registry API, deleted |
 | 9 | `HomeAssistantLabel` | Created via WebSocket registry API, deleted |
 | 10 | `HomeAssistantArea` | Created via WebSocket registry API, deleted |
+
+This job's specs share one Home Assistant bootstrap (real onboarding) and run
+sequentially (`Ordered`), continuing even if one fails (`ContinueOnFailure`)
+so later CRDs are still exercised.
+
+## Coverage Gap Record
+
+No e2e scenario has been intentionally dropped from the gating workflow — all
+25 pre-existing specs are still verified, split across the six jobs above.
+This section exists as the place to record it if a future change ever needs
+to drop a scenario from the gating path rather than fitting it into an
+existing (or new) job:
+
+| Scenario | Why not gating | Where (if anywhere) it's still verified |
+|---|---|---|
+| _(none currently)_ | | |

--- a/test/e2e/e2e_critical_path_test.go
+++ b/test/e2e/e2e_critical_path_test.go
@@ -44,7 +44,7 @@ const (
 	bootstrapInterval  = 10 * time.Second
 )
 
-var _ = Describe("Critical Path E2E", Ordered, ContinueOnFailure, func() {
+var _ = Describe("Critical Path E2E", Ordered, ContinueOnFailure, Label("critical-path"), func() {
 	// Shared state across all tests — set in BeforeAll, used by every It block.
 	var (
 		namespace   string

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -33,20 +33,37 @@ var (
 	// Optional Environment Variables:
 	// - CERT_MANAGER_INSTALL_SKIP=true: Skips CertManager installation during test setup.
 	// - K3D_CLUSTER: Override k3d cluster name (defaults to homeassistant-operator-test-e2e)
+	// - E2E_IMG: Override the operator image reference used by the suite (defaults to
+	//   "example.com/homeassistant-operator:v0.0.1").
+	// - E2E_SKIP_IMAGE_BUILD=true: Skip building/loading the operator image locally and
+	//   use E2E_IMG as-is — for CI jobs that already loaded a pre-built image (e.g. via
+	//   `k3d image import`) so each concurrent job doesn't redundantly rebuild it.
 	// These variables are useful if CertManager is already installed, avoiding
 	// re-installation and conflicts.
 	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
 	// isCertManagerAlreadyInstalled will be set true when CertManager CRDs be found on the cluster
 	isCertManagerAlreadyInstalled = false
 
+	// skipImageBuild skips the local `make docker-build` + k3d image load steps,
+	// using projectImage as an already-loaded image instead.
+	skipImageBuild = os.Getenv("E2E_SKIP_IMAGE_BUILD") == "true"
+
 	// projectImage is the name of the image which will be build and loaded
-	// with the code source changes to be tested.
-	projectImage = "example.com/homeassistant-operator:v0.0.1"
+	// with the code source changes to be tested. Override with E2E_IMG.
+	projectImage = envOrDefault("E2E_IMG", "example.com/homeassistant-operator:v0.0.1")
 
 	// tempKubeconfigPath holds the path to the isolated kubeconfig used by this test run.
 	// It is deleted in SynchronizedAfterSuite.
 	tempKubeconfigPath string
 )
+
+// envOrDefault returns the value of the named environment variable, or def if unset/empty.
+func envOrDefault(name, def string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return def
+}
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
 // temporary k3d cluster to validate project changes for use in CI jobs.
@@ -72,14 +89,18 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		"Cannot isolate kubeconfig for k3d context %q — is the k3d cluster running? "+
 			"Run: make k3d-create", utils.K3dContextName())
 
-	By("building the manager(Operator) image")
-	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
-	_, err := utils.Run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
+	if !skipImageBuild {
+		By("building the manager(Operator) image")
+		cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
 
-	By("loading the manager(Operator) image into k3d cluster")
-	err = utils.LoadImageToK3dClusterWithName(projectImage)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into k3d")
+		By("loading the manager(Operator) image into k3d cluster")
+		err = utils.LoadImageToK3dClusterWithName(projectImage)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into k3d")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "E2E_SKIP_IMAGE_BUILD=true: using pre-loaded image %s\n", projectImage)
+	}
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with CertManager already installed,
@@ -98,7 +119,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	// Shared setup for all E2E tests: Install CRDs and deploy controller once
 	By("installing CRDs")
-	cmd = exec.Command("make", "install")
+	cmd := exec.Command("make", "install")
 	output, err := utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to install CRDs")
 	_, _ = fmt.Fprintf(GinkgoWriter, "CRD installation output:\n%s\n", output)

--- a/test/e2e/homeassistantcommunityrepository_test.go
+++ b/test/e2e/homeassistantcommunityrepository_test.go
@@ -410,7 +410,7 @@ spec:
 	})
 
 	It("installs an integration-category repository, restarting the HA pod",
-		Label("community-repository", "fast"), func() {
+		Label("community-repository", "fast", "group-a"), func() {
 			podStartBefore := utils.Kubectl("get", "pod", haName+"-0", "-n", namespace, "-o", "jsonpath={.status.startTime}")
 
 			hacrYAML := fmt.Sprintf(`apiVersion: ha.homeassistant.io/v1alpha1
@@ -454,7 +454,7 @@ spec:
 		})
 
 	It("installs a theme-category repository without restarting the HA pod",
-		Label("community-repository", "fast"), func() {
+		Label("community-repository", "fast", "group-a"), func() {
 			podStartBefore := utils.Kubectl("get", "pod", haName+"-0", "-n", namespace, "-o", "jsonpath={.status.startTime}")
 
 			hacrYAML := fmt.Sprintf(`apiVersion: ha.homeassistant.io/v1alpha1
@@ -488,7 +488,7 @@ spec:
 		})
 
 	It("installs a python_script-category repository",
-		Label("community-repository", "fast"), func() {
+		Label("community-repository", "fast", "group-b"), func() {
 			hacrYAML := fmt.Sprintf(`apiVersion: ha.homeassistant.io/v1alpha1
 kind: HomeAssistantCommunityRepository
 metadata:
@@ -517,7 +517,7 @@ spec:
 		})
 
 	It("installs a template-category repository",
-		Label("community-repository", "fast"), func() {
+		Label("community-repository", "fast", "group-b"), func() {
 			hacrYAML := fmt.Sprintf(`apiVersion: ha.homeassistant.io/v1alpha1
 kind: HomeAssistantCommunityRepository
 metadata:
@@ -546,7 +546,7 @@ spec:
 		})
 
 	It("installs a plugin-category repository and registers its Lovelace resource",
-		Label("community-repository", "slow"), func() {
+		Label("community-repository", "slow", "group-b"), func() {
 			hacrYAML := fmt.Sprintf(`apiVersion: ha.homeassistant.io/v1alpha1
 kind: HomeAssistantCommunityRepository
 metadata:
@@ -581,7 +581,7 @@ spec:
 		})
 
 	It("keeps installedVersion at the old ref until a ref update is confirmed, then updates it",
-		Label("community-repository", "fast"), func() {
+		Label("community-repository", "fast", "group-a"), func() {
 			Expect(getPhase("e2e-theme")).To(Equal("Installed"))
 			Expect(getInstalledVersion("e2e-theme")).To(Equal("v1.0.0"))
 
@@ -603,7 +603,7 @@ spec:
 		})
 
 	It("removes the ConfigMap entry and the materialized file on deletion",
-		Label("community-repository", "fast"), func() {
+		Label("community-repository", "fast", "group-b"), func() {
 			Expect(getPhase("e2e-python-script")).To(Equal("Installed"))
 
 			cmd := exec.Command("kubectl", "delete", "hacr", "e2e-python-script", "-n", namespace)

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -30,7 +30,7 @@ import (
 // This suite verifies that spec.alpha.networkPolicy.enabled actually restricts
 // traffic to the Home Assistant pod, not just that the NetworkPolicy object
 // exists. k3d/k3s's default CNI enforces NetworkPolicy in this project's CI.
-var _ = Describe("NetworkPolicy E2E", func() {
+var _ = Describe("NetworkPolicy E2E", Label("network-policy"), func() {
 	var (
 		namespace      string
 		probeNamespace string

--- a/test/e2e/pod_security_test.go
+++ b/test/e2e/pod_security_test.go
@@ -35,7 +35,7 @@ import (
 //
 // Prereq: the operator is already deployed by the suite via `make deploy`, which
 // applies the Namespace object (with the PSA labels) onto homeassistant-operator-system.
-var _ = Describe("Pod Security Standards E2E", func() {
+var _ = Describe("Pod Security Standards E2E", Label("pod-security"), func() {
 	const operatorNamespace = "homeassistant-operator-system"
 
 	AfterEach(func() {


### PR DESCRIPTION
…udget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * End-to-end tests now run in six parallel, focused suites, reducing CI execution time.
  * Added isolated coverage for critical paths, TLS, network policies, pod security, and community repository groups.
  * Improved test reliability with guaranteed environment cleanup and support for reusing preloaded operator images.

* **Documentation**
  * Expanded testing guidance with suite selection criteria, local commands, resource behavior, and coverage information.

* **Developer Experience**
  * Added Make targets for running each E2E suite independently and locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->