### PR TITLE
fix(communityrepo): drop per-file size cap that blocked real HACS int…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`HomeAssistantCommunityRepository` no longer rejects repositories over a per-file size limit** — validating a repository whose source tree contains a file larger than 20 MiB failed outright with `tar entry ... is too large`, which blocked real HACS integrations: map-rendering integrations legitimately ship a single generated Python source holding tens of megabytes of base64-encoded map tiles and icons (`Tasshack/dreame-vacuum` was the reported case, at ~26 MiB in one file). The per-file limit is gone. The operator only ever reads the content of small metadata files (`hacs.json`, `custom_components/*/manifest.json`) and merely checks that everything else exists, so a larger file is now indexed without holding its content in memory — which also cuts the operator's peak memory use while validating a large repository (~9 MiB instead of ~37 MiB for the repository above), relevant under the chart's default 128Mi limit. Three archive-wide limits are enforced instead, all fixed and none requiring you to raise the operator's memory limit: 100 MiB cumulative (matching the limit the in-pod init-container/sidecar applies when materializing the same files, so validation and installation agree), 20 000 entries, and a new 32 MiB ceiling on content actually held in memory — that last one covers the archive shape the cumulative limit cannot see (thousands of small files, each cheap, adding up), so such a repository now fails with a diagnosable status on its own resource rather than getting the operator OOM-killed and restarting every reconciler in the cluster. Only pre-release builds of the community-repository feature were affected; see [Troubleshooting](https://przemekhys.github.io/homeassistant-operator/reference/troubleshooting/) for the errors these limits produce.
+
 ### Changed
 
 - **E2E test suite optimization** — CI e2e tests now run faster; see `docs/development/testing.md` (and `.claude/TESTING.md` for AI guidance) for details.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -80,7 +80,7 @@ kubectl get homeassistantcommunityrepository <name> -o jsonpath='{.status.lastEr
 
 There is **no per-file size limit** — a single multi-megabyte source file (some
 integrations ship map or icon assets as base64-encoded Python constants) installs
-normally. Two archive-wide limits can still reject a repository:
+normally. Three archive-wide limits can still reject a repository:
 
 - **`archive exceeds the cumulative extraction limit`** — the repository's contents
   add up to more than **100 MiB** once decompressed. The same limit applies again
@@ -91,12 +91,14 @@ normally. Two archive-wide limits can still reject a repository:
   operator keeps in memory while validating. Large files cost no memory here (only
   their presence is recorded), so this is reached by repositories with thousands of
   small files rather than by large ones.
+- **`archive has too many entries`** — more than 20 000 entries in the tar archive.
+  Every entry counts, not just files: directories, and symlinks and other special
+  entries the operator otherwise skips, all count towards the limit. This is well
+  beyond any HACS-compatible extension; check `spec.repository` points at the
+  extension itself and not at a monorepo or a mirror.
 
-If you hit either, pin `spec.ref` to a release tag rather than a branch: source
+If you hit one of these, pin `spec.ref` to a release tag rather than a branch: source
 tarballs of release tags are usually far smaller than a `main` snapshot carrying full
 documentation and media. Note that raising the operator's own memory limit does not
 lift these limits — they are fixed, so that one oversized repository fails on its own
 resource instead of exhausting the operator process shared by every other resource.
-- **`archive has too many entries`** — more than 20 000 files in the repository,
-  which is well beyond any HACS-compatible extension; check `spec.repository` points
-  at the extension itself and not at a monorepo or a mirror.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -71,3 +71,32 @@ kubectl get homeassistant <name> -o jsonpath='{.status.conditions}' | jq
 - **Native TLS pod not switching to HTTPS** — the pod switches only after the TLS
   Secret exists. Confirm the Secret (`<name>-native-tls`) is populated and that the
   StatefulSet rolled out.
+
+## HomeAssistantCommunityRepository fails with an extraction limit error
+
+```sh
+kubectl get homeassistantcommunityrepository <name> -o jsonpath='{.status.lastError}'
+```
+
+There is **no per-file size limit** — a single multi-megabyte source file (some
+integrations ship map or icon assets as base64-encoded Python constants) installs
+normally. Two archive-wide limits can still reject a repository:
+
+- **`archive exceeds the cumulative extraction limit`** — the repository's contents
+  add up to more than **100 MiB** once decompressed. The same limit applies again
+  inside the Home Assistant pod when the files are written to the config volume, so a
+  larger repository could not be installed anyway.
+- **`archive holds more than ... bytes of small files`** — the repository consists of
+  so many small files (below 1 MiB each) that reading them exceeds the **32 MiB** the
+  operator keeps in memory while validating. Large files cost no memory here (only
+  their presence is recorded), so this is reached by repositories with thousands of
+  small files rather than by large ones.
+
+If you hit either, pin `spec.ref` to a release tag rather than a branch: source
+tarballs of release tags are usually far smaller than a `main` snapshot carrying full
+documentation and media. Note that raising the operator's own memory limit does not
+lift these limits — they are fixed, so that one oversized repository fails on its own
+resource instead of exhausting the operator process shared by every other resource.
+- **`archive has too many entries`** — more than 20 000 files in the repository,
+  which is well beyond any HACS-compatible extension; check `spec.repository` points
+  at the extension itself and not at a monorepo or a mirror.

--- a/internal/communityrepo/fetch.go
+++ b/internal/communityrepo/fetch.go
@@ -46,11 +46,31 @@ var CodeloadBaseURL = "https://codeload.github.com"
 // (or a test fixture server), unlike http.DefaultClient which has none.
 var codeloadHTTPClient = &http.Client{Timeout: 60 * time.Second}
 
-// Limits on in-memory extraction. HACS repos are tiny plain-text source trees
-// (typically kilobytes), so these are generous but still bound worst-case memory
-// use against a malicious or misbehaving upstream repository/host.
+// Limits on extraction, bounding worst-case memory use against a malicious or
+// misbehaving upstream repository/host.
+//
+// maxExtractedTotalBytes matches the cumulative limit the init-container/sidecar
+// enforces while materializing the same archive onto the Home Assistant PVC, so a
+// repository that passes validation here cannot fail later for being too big.
+//
+// maxRetainedEntryBytes is deliberately *not* a rejection threshold: this package
+// only ever reads the content of small metadata files (hacs.json,
+// custom_components/*/manifest.json) and merely checks the existence of everything
+// else, so the content of a larger entry is skipped instead of being held in memory.
+// Rejecting on a per-file size would break legitimate repositories: integrations
+// that render device maps (dreame-vacuum, for one) ship generated Python sources
+// with tens of megabytes of base64-encoded assets in a single file.
+//
+// maxRetainedTotalBytes caps what that skipping leaves behind. Because entries above
+// maxRetainedEntryBytes cost no memory, maxExtractedTotalBytes measures the size of
+// the archive and no longer the memory it needs — an archive of many small files can
+// sit far below it and still be held in full. This second ceiling bounds that: an
+// operator container running at the chart's default 128Mi limit must fail one
+// repository with a diagnosable status rather than be OOM-killed, which would restart
+// every reconciler in the cluster and leave no trace on the resource that caused it.
 const (
-	maxExtractedEntryBytes = 20 * 1024 * 1024  // 20 MiB per file
+	maxRetainedEntryBytes  = 1 * 1024 * 1024   // 1 MiB — above this, content is not kept
+	maxRetainedTotalBytes  = 32 * 1024 * 1024  // 32 MiB of content actually held in memory
 	maxExtractedTotalBytes = 100 * 1024 * 1024 // 100 MiB cumulative across the archive
 	maxExtractedEntries    = 20000             // archive entry count
 )
@@ -60,10 +80,21 @@ const (
 // memory — never written to disk — because the operator container runs with
 // readOnlyRootFilesystem and no writable /tmp (a production deployment default;
 // os.MkdirTemp there fails outright, which is exactly the bug this design avoids).
-// HACS repos are tiny plain-text source trees, so holding them in memory is cheap.
+// Every regular file of the archive is listed, but only content below
+// maxRetainedEntryBytes is held (see that constant), which keeps the memory cost
+// close to the size of the repository's metadata rather than of its assets.
 type ExtractedRepo struct {
-	files map[string][]byte // cleaned relative path -> content, regular files only
-	dirs  map[string]bool   // cleaned relative path -> true, includes intermediate dirs
+	files map[string]fileEntry // cleaned relative path -> entry, regular files only
+	dirs  map[string]bool      // cleaned relative path -> true, includes intermediate dirs
+}
+
+// fileEntry is one regular file of the archive. content is nil and retained is
+// false for a file whose content was skipped as too large to hold in memory; size
+// is the declared size either way, so ReadFile can explain itself.
+type fileEntry struct {
+	content  []byte
+	retained bool
+	size     int64
 }
 
 // DirEntry is one entry returned by ExtractedRepo.ReadDir.
@@ -74,12 +105,19 @@ type DirEntry struct {
 
 // ReadFile returns the content of the file at the given path (relative to the
 // repository root), or an error satisfying errors.Is(err, ErrNotExist) if absent.
+// A file larger than maxRetainedEntryBytes exists but has no content held in
+// memory; reading it returns an error satisfying errors.Is(err, ErrContentNotRetained).
 func (e *ExtractedRepo) ReadFile(p string) ([]byte, error) {
 	clean := path.Clean(p)
-	if data, ok := e.files[clean]; ok {
-		return data, nil
+	entry, ok := e.files[clean]
+	if !ok {
+		return nil, fmt.Errorf("%s: %w", p, ErrNotExist)
 	}
-	return nil, fmt.Errorf("%s: %w", p, ErrNotExist)
+	if !entry.retained {
+		return nil, fmt.Errorf("%s (%d bytes, retained up to %d): %w",
+			p, entry.size, maxRetainedEntryBytes, ErrContentNotRetained)
+	}
+	return entry.content, nil
 }
 
 // ReadDir lists the entries directly inside the given directory (relative to the
@@ -136,14 +174,23 @@ func directChild(parent, childPath string) (name string, ok bool) {
 	return rest, true
 }
 
-// Exists reports whether the given path (file or directory) exists.
+// Exists reports whether the given path (file or directory) exists, regardless of
+// whether the file's content was retained.
 func (e *ExtractedRepo) Exists(p string) bool {
 	clean := path.Clean(p)
-	return e.files[clean] != nil || e.dirs[clean]
+	if _, ok := e.files[clean]; ok {
+		return true
+	}
+	return e.dirs[clean]
 }
 
 // ErrNotExist is returned by ExtractedRepo methods for a missing path.
 var ErrNotExist = errors.New("path does not exist")
+
+// ErrContentNotRetained is returned by ReadFile for a file that exists in the
+// archive but whose content was too large to hold in memory (see
+// maxRetainedEntryBytes).
+var ErrContentNotRetained = errors.New("file content was not retained in memory")
 
 // FetchTarball downloads the tarball for repository ("owner/repo") at ref (tag,
 // branch, or commit) and extracts it entirely in memory, stripping the tarball's
@@ -177,11 +224,12 @@ func FetchTarball(ctx context.Context, repository, ref string) (*ExtractedRepo, 
 	return stripTopLevelDir(extracted)
 }
 
-// extractTarGz reads a gzip-compressed tar stream fully into memory, enforcing
-// bounded extraction (maxExtractedEntryBytes/maxExtractedTotalBytes/
-// maxExtractedEntries) against a decompression bomb or a runaway/malicious
-// archive — decompressed size is what matters here (not the compressed transfer
-// size), since gzip can expand many times over.
+// extractTarGz reads a gzip-compressed tar stream into memory, enforcing bounded
+// extraction (maxExtractedTotalBytes/maxExtractedEntries) against a decompression
+// bomb or a runaway/malicious archive — decompressed size is what matters here
+// (not the compressed transfer size), since gzip can expand many times over.
+// Entries above maxRetainedEntryBytes are indexed by path but their content is
+// streamed past rather than held.
 func extractTarGz(r io.Reader) (*ExtractedRepo, error) {
 	gz, err := gzip.NewReader(r)
 	if err != nil {
@@ -189,9 +237,9 @@ func extractTarGz(r io.Reader) (*ExtractedRepo, error) {
 	}
 	defer func() { _ = gz.Close() }()
 
-	extracted := &ExtractedRepo{files: map[string][]byte{}, dirs: map[string]bool{}}
+	extracted := &ExtractedRepo{files: map[string]fileEntry{}, dirs: map[string]bool{}}
 
-	var totalBytes int64
+	var totalBytes, retainedBytes int64
 	var entryCount int
 	tr := tar.NewReader(gz)
 	for {
@@ -219,24 +267,33 @@ func extractTarGz(r io.Reader) (*ExtractedRepo, error) {
 			extracted.dirs[name] = true
 			markParentDirs(extracted.dirs, name)
 		case tar.TypeReg:
-			if hdr.Size > maxExtractedEntryBytes {
-				return nil, fmt.Errorf("tar entry %q is too large (%d bytes, limit %d)",
-					hdr.Name, hdr.Size, maxExtractedEntryBytes)
+			if hdr.Size < 0 {
+				return nil, fmt.Errorf("tar entry %q declares a negative size (%d)", hdr.Name, hdr.Size)
 			}
 			totalBytes += hdr.Size
 			if totalBytes > maxExtractedTotalBytes {
 				return nil, fmt.Errorf("archive exceeds the cumulative extraction limit (%d bytes)", maxExtractedTotalBytes)
 			}
-			// LimitReader is a defense-in-depth backstop against a tar header lying
-			// about hdr.Size while the actual entry stream contains more data.
-			data, err := io.ReadAll(io.LimitReader(tr, maxExtractedEntryBytes+1))
-			if err != nil {
-				return nil, fmt.Errorf("failed to read %q: %w", hdr.Name, err)
+			entry := fileEntry{size: hdr.Size}
+			if hdr.Size <= maxRetainedEntryBytes {
+				retainedBytes += hdr.Size
+				if retainedBytes > maxRetainedTotalBytes {
+					return nil, fmt.Errorf(
+						"archive holds more than %d bytes of small files, too much to keep in memory",
+						maxRetainedTotalBytes)
+				}
+				// Allocate exactly the declared size and read into it: io.ReadAll
+				// would grow its buffer by doubling, transiently costing several
+				// times the file size in an operator container that runs with a
+				// modest memory limit. tar.Reader never yields more than hdr.Size
+				// bytes for an entry, so no separate cap on the read is needed.
+				entry.content = make([]byte, hdr.Size)
+				if _, err := io.ReadFull(tr, entry.content); err != nil {
+					return nil, fmt.Errorf("failed to read %q: %w", hdr.Name, err)
+				}
+				entry.retained = true
 			}
-			if int64(len(data)) > maxExtractedEntryBytes {
-				return nil, fmt.Errorf("tar entry %q is too large (limit %d bytes)", hdr.Name, maxExtractedEntryBytes)
-			}
-			extracted.files[name] = data
+			extracted.files[name] = entry
 			markParentDirs(extracted.dirs, name)
 		default:
 			// Skip symlinks and other special entries — HACS repos are plain source trees.
@@ -283,10 +340,10 @@ func stripTopLevelDir(extracted *ExtractedRepo) (*ExtractedRepo, error) {
 		prefix = d + "/"
 	}
 
-	stripped := &ExtractedRepo{files: map[string][]byte{}, dirs: map[string]bool{}}
-	for p, data := range extracted.files {
+	stripped := &ExtractedRepo{files: map[string]fileEntry{}, dirs: map[string]bool{}}
+	for p, entry := range extracted.files {
 		if rel, ok := strings.CutPrefix(p, prefix); ok && rel != "" {
-			stripped.files[rel] = data
+			stripped.files[rel] = entry
 		}
 	}
 	for p := range extracted.dirs {

--- a/internal/communityrepo/fetch_test.go
+++ b/internal/communityrepo/fetch_test.go
@@ -25,12 +25,21 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 // buildTarball builds a gzip-compressed tarball containing files, wrapped in a single
 // top-level directory named prefix (mirroring GitHub codeload's "owner-repo-sha/" layout).
 func buildTarball(t *testing.T, prefix string, files map[string]string) []byte {
+	t.Helper()
+	return buildTarballWith(t, prefix, files, nil)
+}
+
+// buildTarballWith additionally writes entries given only by size, filling them with
+// placeholder bytes streamed in chunks — so a multi-megabyte entry never has to be
+// materialized in the test itself.
+func buildTarballWith(t *testing.T, prefix string, files map[string]string, sized map[string]int64) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)
@@ -52,6 +61,28 @@ func buildTarball(t *testing.T, prefix string, files map[string]string) []byte {
 		}
 		if _, err := tw.Write([]byte(content)); err != nil {
 			t.Fatalf("write content for %s: %v", full, err)
+		}
+	}
+	chunk := bytes.Repeat([]byte("a"), 1024*1024)
+	for name, size := range sized {
+		full := prefix + "/" + name
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     full,
+			Typeflag: tar.TypeReg,
+			Mode:     0o644,
+			Size:     size,
+		}); err != nil {
+			t.Fatalf("write header for %s: %v", full, err)
+		}
+		for remaining := size; remaining > 0; {
+			n := int64(len(chunk))
+			if remaining < n {
+				n = remaining
+			}
+			if _, err := tw.Write(chunk[:n]); err != nil {
+				t.Fatalf("write content for %s: %v", full, err)
+			}
+			remaining -= n
 		}
 	}
 	if err := tw.Close(); err != nil {
@@ -227,39 +258,103 @@ func TestExtractedRepo_ReadDir_Root(t *testing.T) {
 	}
 }
 
-func TestExtractTarGz_RejectsOversizedEntry(t *testing.T) {
-	oversized := bytes.Repeat([]byte("a"), maxExtractedEntryBytes+1)
+// TestFetchTarball_LargeEntryStaysVisible pins the behavior that makes a real HACS
+// integration installable: a file too large to hold in memory is still part of the
+// repository view (it is listed and it exists), only its content is not retained.
+func TestFetchTarball_LargeEntryStaysVisible(t *testing.T) {
+	tarball := buildTarballWith(t, "owner-repo-abc123",
+		map[string]string{"hacs.json": `{"name":"Test"}`},
+		map[string]int64{"assets/resources.py": maxRetainedEntryBytes + 1},
+	)
+	withMockCodeload(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tarball)
+	})
 
-	var buf bytes.Buffer
-	gz := gzip.NewWriter(&buf)
-	tw := tar.NewWriter(gz)
-	if err := tw.WriteHeader(&tar.Header{
-		Name:     "owner-repo-abc123/big-file",
-		Typeflag: tar.TypeReg,
-		Mode:     0o644,
-		Size:     int64(len(oversized)),
-	}); err != nil {
-		t.Fatalf("write header: %v", err)
-	}
-	if _, err := tw.Write(oversized); err != nil {
-		t.Fatalf("write content: %v", err)
-	}
-	if err := tw.Close(); err != nil {
-		t.Fatalf("close tar: %v", err)
-	}
-	if err := gz.Close(); err != nil {
-		t.Fatalf("close gzip: %v", err)
+	repo, err := FetchTarball(context.Background(), "owner/repo", "main")
+	if err != nil {
+		t.Fatalf("FetchTarball() error = %v", err)
 	}
 
-	if _, err := extractTarGz(bytes.NewReader(buf.Bytes())); err == nil {
-		t.Fatal("expected extractTarGz to reject an oversized entry")
+	if !repo.Exists("assets/resources.py") {
+		t.Error("expected the large entry to exist in the repository view")
+	}
+	entries, err := repo.ReadDir("assets")
+	if err != nil || len(entries) != 1 || entries[0].Name != "resources.py" {
+		t.Errorf("expected ReadDir to list the large entry, got %+v (err = %v)", entries, err)
+	}
+	if _, err := repo.ReadFile("assets/resources.py"); !errors.Is(err, ErrContentNotRetained) {
+		t.Errorf("expected ErrContentNotRetained reading the large entry, got %v", err)
+	}
+	if data, err := repo.ReadFile("hacs.json"); err != nil || len(data) == 0 {
+		t.Errorf("expected small files to keep their content, got %q (err = %v)", data, err)
+	}
+}
+
+// TestValidateAndResolve_IntegrationWithMultiMegabyteSource mirrors integrations that
+// ship generated Python sources holding tens of megabytes of base64-encoded assets
+// (map tiles, icons) in a single file: validation must resolve them like any other.
+func TestValidateAndResolve_IntegrationWithMultiMegabyteSource(t *testing.T) {
+	tarball := buildTarballWith(t, "owner-repo-abc123",
+		map[string]string{
+			"hacs.json": `{"name":"Test","category":"integration"}`,
+			"custom_components/my_integration/manifest.json": `{"domain":"my_integration"}`,
+			"custom_components/my_integration/__init__.py":   "",
+		},
+		map[string]int64{"custom_components/my_integration/resources.py": 30 * 1024 * 1024},
+	)
+	withMockCodeload(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tarball)
+	})
+
+	repo, err := FetchTarball(context.Background(), "owner/repo", "main")
+	if err != nil {
+		t.Fatalf("FetchTarball() error = %v", err)
+	}
+	resolved, err := ValidateAndResolve(repo, CategoryIntegration)
+	if err != nil {
+		t.Fatalf("ValidateAndResolve() error = %v", err)
+	}
+	if resolved.ResolvedTarget != "my_integration" {
+		t.Errorf("ResolvedTarget = %q, want %q", resolved.ResolvedTarget, "my_integration")
+	}
+}
+
+// TestExtractTarGz_RejectsExceedingRetainedLimit covers the archive shape the
+// cumulative guard cannot see: every entry is small enough for its content to be
+// kept, so the archive stays under maxExtractedTotalBytes while the memory it needs
+// does not. Rejecting it must be a diagnosable error, not an OOM kill.
+func TestExtractTarGz_RejectsExceedingRetainedLimit(t *testing.T) {
+	const entrySize = maxRetainedEntryBytes // retained, being at the threshold
+	entryCount := int(maxRetainedTotalBytes/entrySize) + 2
+
+	sized := map[string]int64{}
+	for i := 0; i < entryCount; i++ {
+		sized[fmt.Sprintf("file-%d", i)] = entrySize
+	}
+	tarball := buildTarballWith(t, "owner-repo-abc123", nil, sized)
+
+	if int64(entryCount)*entrySize > maxExtractedTotalBytes {
+		t.Fatalf("test archive (%d bytes) must stay under the cumulative limit to be meaningful",
+			int64(entryCount)*entrySize)
+	}
+	_, err := extractTarGz(bytes.NewReader(tarball))
+	if err == nil {
+		t.Fatal("expected extractTarGz to reject an archive holding too much content in memory")
+	}
+	// Assert on the reason, not just on failure: a rejection coming from one of the
+	// other guards would mean this archive shape is still unchecked.
+	if !strings.Contains(err.Error(), "keep in memory") {
+		t.Errorf("expected the retained-content guard to reject, got %v", err)
 	}
 }
 
 func TestExtractTarGz_RejectsExceedingCumulativeLimit(t *testing.T) {
-	// Each entry stays well under maxExtractedEntryBytes, but enough of them
-	// together exceed maxExtractedTotalBytes — this must be rejected on its own,
-	// independent of the per-entry guard.
+	// The cumulative guard counts every regular entry, whether or not its content
+	// is retained in memory — it bounds the archive as a whole. Entries here are
+	// far above maxRetainedEntryBytes, so nothing is retained and this exercises
+	// the cumulative guard alone.
 	const chunkSize = 10 * 1024 * 1024 // 10 MiB
 	chunkCount := int(maxExtractedTotalBytes/chunkSize) + 2
 	chunk := bytes.Repeat([]byte("a"), chunkSize)

--- a/internal/communityrepo/manifest_test.go
+++ b/internal/communityrepo/manifest_test.go
@@ -25,10 +25,10 @@ import (
 // buildExtractedRepo constructs an in-memory ExtractedRepo directly from a
 // relative-path -> content map, without going through FetchTarball/HTTP.
 func buildExtractedRepo(files map[string]string) *ExtractedRepo {
-	repo := &ExtractedRepo{files: map[string][]byte{}, dirs: map[string]bool{}}
+	repo := &ExtractedRepo{files: map[string]fileEntry{}, dirs: map[string]bool{}}
 	for rel, content := range files {
 		clean := path.Clean(rel)
-		repo.files[clean] = []byte(content)
+		repo.files[clean] = fileEntry{content: []byte(content), retained: true, size: int64(len(content))}
 		markParentDirs(repo.dirs, clean)
 	}
 	return repo


### PR DESCRIPTION
…egrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Community repository archives can now include individual files larger than the previous per-file limit.
  - Large files remain available for archive listing and validation, while cumulative extraction, entry-count, and in-memory retention limits continue to protect reliability.
  - Improved handling of large repository sources during extension resolution.

- **Documentation**
  - Added troubleshooting guidance for extraction-limit errors, including supported archive limits and recommendations for using release tags and correct repository locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->