### PR TITLE
chore(renovate): watch dev branch, enable vuln + indirect Go deps

### DIFF
--- a/docs/development/branching.md
+++ b/docs/development/branching.md
@@ -58,6 +58,24 @@ Resolve any conflicts in favour of keeping both the fix and the in-progress
 feature work. Never rebase `dev` onto `main` or force-push either branch —
 both are shared.
 
+## Automated dependency updates (Renovate)
+
+Renovate (`renovate.json`) watches **both** long-lived branches
+(`baseBranches: ["main", "dev"]`) and opens separate PRs per branch:
+
+- **`main`** receives only non-breaking updates — `minor`, `patch`, `digest`,
+  `pin`. These merge like any other fix and ship as a patch release; the
+  `main` → `dev` sync above then carries them forward.
+- **`dev`** additionally receives `major` / breaking dependency bumps, so they
+  are integrated and tested during the feature cycle and only reach `main`
+  through an RC — never as a surprise on the released line.
+- Security fixes (`osvVulnerabilityAlerts`) are raised against whichever
+  branch carries the vulnerable version, without waiting for a release cycle.
+
+When `main` and `dev` hold the same dependency state you will get two
+near-identical PRs; merge the `main` one, and the routine `git merge --no-ff
+main` into `dev` makes Renovate close the redundant `dev` PR on its next run.
+
 ## Release candidates
 
 - RC tags follow SemVer prerelease syntax: `v1.4.0-rc.1`, `v1.4.0-rc.2`, …

--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,32 @@
   "extends": ["config:recommended"],
   "timezone": "UTC",
   "schedule": ["at any time"],
+  "baseBranches": ["main", "dev"],
   "enabledManagers": ["gomod", "github-actions", "dockerfile", "custom.regex"],
   "commitMessagePrefix": "chore(deps):",
   "dependencyDashboard": false,
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "packageRules": [
     {
-      "matchPackagePatterns": [".*"],
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "groupName": "all dependencies"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true,
+      "groupName": "indirect go deps"
+    },
+    {
+      "description": "Keep main on non-breaking updates only; majors/breaking changes are integrated and tested on dev first (see docs/development/branching.md)",
+      "matchBaseBranches": ["main"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on automated dependency updates across development branches.
  * Documented security update handling, update limits, and duplicate pull request resolution.

* **Chores**
  * Improved dependency update automation, including vulnerability alerts and Go module maintenance.
  * Grouped related indirect dependencies for more manageable updates.
  * Restricted major dependency updates on the stable branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->