### PR TITLE
fix(renovate): stop auto-bumping indirect Go deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,10 +19,10 @@
       "groupName": "all dependencies"
     },
     {
+      "description": "Indirect Go deps float with their parents. Renovate's default (indirect updates disabled) avoids standalone bumps across module renames / replace directives. Real CVEs in indirect deps are still raised via osvVulnerabilityAlerts.",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
-      "enabled": true,
-      "groupName": "indirect go deps"
+      "enabled": false
     },
     {
       "description": "Keep main on non-breaking updates only; majors/breaking changes are integrated and tested on dev first (see docs/development/branching.md)",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings so indirect Go dependencies follow their parent modules.
  * Vulnerability monitoring remains available through OSV alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->