### PR TITLE
fix(config): don't bounce the pod on the YAML→API http switch, and on…

### DIFF
--- a/internal/controller/homeassistantconfiguration_controller.go
+++ b/internal/controller/homeassistantconfiguration_controller.go
@@ -224,8 +224,10 @@ func (r *HomeAssistantConfigurationReconciler) Reconcile(ctx context.Context, re
 	// restart-vs-hot-reload decision — Home Assistant restarts its own process
 	// when the API change needs it. Strip http: from both sides so its
 	// appearance/disappearance never drives a pod rollout (a second restart).
+	oldHadHTTP := false
 	if httpDecision.path == httpPathAPI && httpReadable {
 		if stripped, serr := stripHTTPSection(oldConfig); serr == nil {
+			oldHadHTTP = stripped != oldConfig
 			oldConfig = stripped
 		}
 	}
@@ -262,7 +264,8 @@ func (r *HomeAssistantConfigurationReconciler) Reconcile(ctx context.Context, re
 	}
 
 	// Perform configuration reload if hash changed or if ConfigMap was restored from external edit
-	if config.Status.ConfigHash != configHash || syncedContent {
+	if (config.Status.ConfigHash != configHash || syncedContent) &&
+		!isDeliveryChannelSwitchOnly(oldHadHTTP, syncedContent, oldConfig, canonicalContent) {
 		if err := r.performConfigReload(ctx, config, ha, configHash, oldConfig, canonicalContent); err != nil {
 			log.Error(err, "Failed to reload configuration")
 			meta.SetStatusCondition(&config.Status.Conditions, metav1.Condition{
@@ -415,6 +418,17 @@ func (r *HomeAssistantConfigurationReconciler) SetupWithManager(mgr ctrl.Manager
 		).
 		Named("homeassistantconfiguration").
 		Complete(r)
+}
+
+// isDeliveryChannelSwitchOnly reports whether the only reason the generated
+// configuration changed this reconcile is that http: moved from configuration.yaml
+// to the Home Assistant API (both sides are identical once http: is excluded).
+// That is a one-time transition on upgrade, not a configuration change: the http
+// settings are applied by reconcileHTTPConfig and the rest of the file is
+// unchanged, so no reload — and no pod rollout — is needed. An external ConfigMap
+// edit (syncedContent) is always a real change and is never treated as a switch.
+func isDeliveryChannelSwitchOnly(oldHadHTTP, syncedContent bool, oldConfig, canonicalContent string) bool {
+	return oldHadHTTP && !syncedContent && oldConfig == canonicalContent
 }
 
 // needsRestart analyzes configuration changes and determines if restart is required

--- a/internal/controller/http_config_fields_test.go
+++ b/internal/controller/http_config_fields_test.go
@@ -101,3 +101,25 @@ func toIfaceList(s []string) []interface{} {
 	}
 	return out
 }
+
+func TestIsDeliveryChannelSwitchOnly(t *testing.T) {
+	const same = "default_config:\nlogger:\n  default: info\n"
+	cases := []struct {
+		name               string
+		oldHadHTTP, synced bool
+		oldConfig, canon   string
+		want               bool
+	}{
+		{"pure YAML->API transition", true, false, same, same, true},
+		{"transition plus a real config change", true, false, same, same + "recorder:\n", false},
+		{"external ConfigMap edit is never a switch", true, true, same, same, false},
+		{"no http: to begin with", false, false, same, same, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isDeliveryChannelSwitchOnly(c.oldHadHTTP, c.synced, c.oldConfig, c.canon); got != c.want {
+				t.Fatalf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/controller/tls_helpers.go
+++ b/internal/controller/tls_helpers.go
@@ -285,9 +285,13 @@ func (r *HomeAssistantReconciler) reconcileNativeTLSRemoval(ctx context.Context,
 	getErr := r.Get(ctx, client.ObjectKey{Name: nativeTLSCertificateName(ha), Namespace: ha.Namespace}, cert)
 	switch {
 	case getErr == nil:
-		certExisted = true
-		if err := r.deleteCertificate(ctx, ha, nativeTLSCertificateName(ha)); err != nil {
-			return err
+		// Only touch a Certificate this operator created for this instance — a
+		// user-managed Certificate that happens to share the name is left alone.
+		if ref := metav1.GetControllerOf(cert); ref != nil && ref.UID == ha.UID {
+			certExisted = true
+			if err := r.deleteCertificate(ctx, ha, nativeTLSCertificateName(ha)); err != nil {
+				return err
+			}
 		}
 	case apierrors.IsNotFound(getErr), meta.IsNoMatchError(getErr):
 		// Nothing to delete (already gone, or cert-manager not installed).

--- a/internal/controller/tls_helpers.go
+++ b/internal/controller/tls_helpers.go
@@ -139,13 +139,19 @@ func (r *HomeAssistantReconciler) ensureCertificate(
 
 // deleteCertificate removes an operator-managed Certificate by name if present.
 // Best-effort: NotFound is ignored, and a missing cert-manager CRD (NoMatchError)
-// means there is nothing to delete.
-func (r *HomeAssistantReconciler) deleteCertificate(ctx context.Context, ha *hav1.HomeAssistant, name string) error {
+// means there is nothing to delete. Callers that first fetched and validated the
+// Certificate should pass client.Preconditions{UID: ...} so a delete+recreate
+// between their Get and this Delete cannot remove the replacement object; the
+// resulting Conflict is treated like NotFound (the object we validated is gone).
+func (r *HomeAssistantReconciler) deleteCertificate(
+	ctx context.Context, ha *hav1.HomeAssistant, name string, opts ...client.DeleteOption,
+) error {
 	cert := &unstructured.Unstructured{}
 	cert.SetGroupVersionKind(certificateGVK)
 	cert.SetName(name)
 	cert.SetNamespace(ha.Namespace)
-	if err := r.Delete(ctx, cert); err != nil && !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+	if err := r.Delete(ctx, cert, opts...); err != nil &&
+		!apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) && !apierrors.IsConflict(err) {
 		return err
 	}
 	return nil
@@ -289,7 +295,13 @@ func (r *HomeAssistantReconciler) reconcileNativeTLSRemoval(ctx context.Context,
 		// user-managed Certificate that happens to share the name is left alone.
 		if ref := metav1.GetControllerOf(cert); ref != nil && ref.UID == ha.UID {
 			certExisted = true
-			if err := r.deleteCertificate(ctx, ha, nativeTLSCertificateName(ha)); err != nil {
+			// Pin the delete to the UID we just validated: if the Certificate is
+			// replaced between this Get and the Delete, the precondition fails and
+			// deleteCertificate swallows the Conflict instead of removing a
+			// same-named object we do not own.
+			uid := cert.GetUID()
+			if err := r.deleteCertificate(ctx, ha, nativeTLSCertificateName(ha),
+				client.Preconditions{UID: &uid}); err != nil {
 				return err
 			}
 		}

--- a/internal/controller/tls_helpers_test.go
+++ b/internal/controller/tls_helpers_test.go
@@ -18,10 +18,12 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -32,6 +34,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	hav1 "github.com/przemekhys/homeassistant-operator/api/v1"
 )
@@ -51,6 +54,12 @@ func restMapperWithCertManager(present bool) meta.RESTMapper {
 }
 
 func newTLSTestReconciler(t *testing.T, certManagerPresent bool, objs ...client.Object) *HomeAssistantReconciler {
+	return newTLSTestReconcilerWithFuncs(t, certManagerPresent, interceptor.Funcs{}, objs...)
+}
+
+func newTLSTestReconcilerWithFuncs(
+	t *testing.T, certManagerPresent bool, funcs interceptor.Funcs, objs ...client.Object,
+) *HomeAssistantReconciler {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	if err := hav1.AddToScheme(scheme); err != nil {
@@ -71,6 +80,7 @@ func newTLSTestReconciler(t *testing.T, certManagerPresent bool, objs ...client.
 		WithRESTMapper(restMapperWithCertManager(certManagerPresent)).
 		WithObjects(objs...).
 		WithStatusSubresource(&hav1.HomeAssistant{}).
+		WithInterceptorFuncs(funcs).
 		Build()
 	return &HomeAssistantReconciler{
 		Client:   cl,
@@ -350,6 +360,44 @@ func TestReconcileNativeTLSRemoval(t *testing.T) {
 			if strings.Contains(e, eventNativeTLSRemoved) {
 				t.Fatalf("unexpected %s event for a foreign Certificate", eventNativeTLSRemoved)
 			}
+		}
+	})
+
+	t.Run("Certificate replaced between the validating Get and the Delete is not removed", func(t *testing.T) {
+		ha := withCondition(&hav1.HomeAssistant{
+			ObjectMeta: metav1.ObjectMeta{Name: "home", Namespace: "default", UID: "home-uid"},
+		}, conditionTLSReady)
+		owned := nativeCert(ha)
+		owned.SetUID("native-cert-uid")
+
+		var gotUID *types.UID
+		funcs := interceptor.Funcs{
+			Delete: func(
+				_ context.Context, _ client.WithWatch, _ client.Object, opts ...client.DeleteOption,
+			) error {
+				do := &client.DeleteOptions{}
+				do.ApplyOptions(opts)
+				if do.Preconditions != nil {
+					gotUID = do.Preconditions.UID
+				}
+				// Simulate the object having been deleted and recreated with a
+				// different identity since reconcileNativeTLSRemoval fetched it:
+				// the API server rejects the UID precondition with a Conflict.
+				return apierrors.NewConflict(
+					certificateGVK.GroupVersion().WithResource("certificates").GroupResource(),
+					owned.GetName(), errors.New("uid precondition mismatch"))
+			},
+		}
+		r := newTLSTestReconcilerWithFuncs(t, true, funcs, ha, owned)
+
+		if err := r.reconcileNativeTLSRemoval(ctx, ha); err != nil {
+			t.Fatalf("reconcileNativeTLSRemoval must swallow the precondition Conflict, got: %v", err)
+		}
+		if gotUID == nil || *gotUID != "native-cert-uid" {
+			t.Fatalf("delete must be pinned to the validated Certificate UID, got %v", gotUID)
+		}
+		if meta.FindStatusCondition(ha.Status.Conditions, conditionTLSReady) != nil {
+			t.Fatal("cleanup should still strip TLSReady after a tolerated delete Conflict")
 		}
 	})
 

--- a/internal/controller/tls_helpers_test.go
+++ b/internal/controller/tls_helpers_test.go
@@ -27,7 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -81,7 +83,7 @@ func newTLSTestReconciler(t *testing.T, certManagerPresent bool, objs ...client.
 // issuerRef — i.e. a mode that needs cert-manager.
 func ingressTLSHA(name string) *hav1.HomeAssistant {
 	return &hav1.HomeAssistant{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: types.UID(name + "-uid")},
 		Spec: hav1.HomeAssistantSpec{
 			Ingress: &hav1.IngressSpec{
 				Enabled: true,
@@ -236,8 +238,23 @@ func TestReconcileTLSAvailableSetsCondition(t *testing.T) {
 }
 
 // nativeCert builds the (now-obsolete) operator-managed native TLS Certificate
-// object for ha, as a transition-era instance would still have on the cluster.
+// object for ha, with the controller owner reference the operator would have set,
+// as a transition-era instance would still have on the cluster.
 func nativeCert(ha *hav1.HomeAssistant) *unstructured.Unstructured {
+	c := foreignCert(ha)
+	c.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: hav1.GroupVersion.String(),
+		Kind:       "HomeAssistant",
+		Name:       ha.Name,
+		UID:        ha.UID,
+		Controller: ptr.To(true),
+	}})
+	return c
+}
+
+// foreignCert is a Certificate sharing the native-TLS name but NOT owned by the
+// operator — a user-managed resource the cleanup must leave alone.
+func foreignCert(ha *hav1.HomeAssistant) *unstructured.Unstructured {
 	c := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	c.SetGroupVersionKind(certificateGVK)
 	c.SetName(nativeTLSCertificateName(ha))
@@ -280,7 +297,7 @@ func TestReconcileNativeTLSRemoval(t *testing.T) {
 
 	t.Run("removes condition + certificate and emits one warning", func(t *testing.T) {
 		ha := withCondition(&hav1.HomeAssistant{
-			ObjectMeta: metav1.ObjectMeta{Name: "home", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "home", Namespace: "default", UID: "home-uid"},
 		}, conditionTLSReady)
 		r := newTLSTestReconciler(t, true, ha, nativeCert(ha))
 
@@ -319,6 +336,23 @@ func TestReconcileNativeTLSRemoval(t *testing.T) {
 		}
 	})
 
+	t.Run("does not delete a same-named Certificate the operator does not own", func(t *testing.T) {
+		ha := &hav1.HomeAssistant{ObjectMeta: metav1.ObjectMeta{Name: "home", Namespace: "default", UID: "home-uid"}}
+		r := newTLSTestReconciler(t, true, ha, foreignCert(ha))
+
+		if err := r.reconcileNativeTLSRemoval(ctx, ha); err != nil {
+			t.Fatalf("reconcileNativeTLSRemoval error: %v", err)
+		}
+		if certGone(t, r, ha) {
+			t.Fatal("a user-managed Certificate sharing the native-TLS name must not be deleted")
+		}
+		for _, e := range warningEvents(r) {
+			if strings.Contains(e, eventNativeTLSRemoved) {
+				t.Fatalf("unexpected %s event for a foreign Certificate", eventNativeTLSRemoved)
+			}
+		}
+	})
+
 	t.Run("keeps CertManagerAvailable when an edge TLS mode still needs it", func(t *testing.T) {
 		ha := withCondition(ingressTLSHA("edge"), conditionTLSReady)
 		withCondition(ha, conditionCertManagerAvailable)
@@ -337,7 +371,7 @@ func TestReconcileNativeTLSRemoval(t *testing.T) {
 
 	t.Run("idempotent: second run is a no-op with no extra event", func(t *testing.T) {
 		ha := withCondition(&hav1.HomeAssistant{
-			ObjectMeta: metav1.ObjectMeta{Name: "home", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "home", Namespace: "default", UID: "home-uid"},
 		}, conditionTLSReady)
 		r := newTLSTestReconciler(t, true, ha, nativeCert(ha))
 


### PR DESCRIPTION
…ly delete owned native-TLS certificate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary Home Assistant pod rollouts when configuration changes only reflect the internal HTTP delivery-channel transition.
  - Protected user-managed TLS certificates from accidental deletion when they share the native certificate name.

- **Tests**
  - Added coverage for configuration transition detection and certificate ownership safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->