### PR TITLE
fix(gateway): allow selecting managed GatewayClass

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,12 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore build and test binaries.
 bin/
+.git/
+Dockerfile*
+.dockerignore
+*.log*
+.env*
+coverage/
+node_modules/
+.venv/
+site/

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,21 @@ go.work
 *~
 
 # env file
-.env
+.env*
+
+# Local logs and temporary files
+*.log
+*.tmp
+.DS_Store
+Thumbs.db
+
+# Local Kubernetes credentials and secrets
+*.secret.yaml
+secrets/
+.kube/
+kubeconfig*
+*.key
+*.crt
 
 .devcontainer/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Operator-managed Gateways could not select a cluster GatewayClass (#202).**
+  `spec.gateway.gatewayClassName` now selects an existing class without any
+  GatewayClass lookup or ownership. The field defaults to `traefik` when
+  omitted; clusters using another Gateway controller must select its class
+  explicitly.
+
 ## [v1.4.0] - 2026-09-01
 
 ### Fixed

--- a/api/v1/homeassistant_types.go
+++ b/api/v1/homeassistant_types.go
@@ -225,6 +225,16 @@ type GatewaySpec struct {
 	// +optional
 	ManageGateway bool `json:"manageGateway,omitempty"`
 
+	// GatewayClassName names the existing GatewayClass used by the
+	// operator-created Gateway. Defaults to "traefik" when omitted. Ignored when
+	// ParentRef is set.
+	// +optional
+	// +kubebuilder:default=traefik
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	GatewayClassName string `json:"gatewayClassName,omitempty"`
+
 	// Filters are HTTP route-level behaviors (header modification, redirect, URL
 	// rewrite) applied, in order, to the single HTTPRoute rule the operator
 	// manages for this instance. Omitted/empty leaves the route unchanged from

--- a/charts/homeassistant-operator/.helmignore
+++ b/charts/homeassistant-operator/.helmignore
@@ -1,4 +1,5 @@
 .DS_Store
+Thumbs.db
 .git
 .gitignore
 .idea/
@@ -6,6 +7,9 @@
 *.swp
 *.bak
 *.orig
+*.tmp
+*.log
+.env*
 *.tmproj
 OWNERS
 OWNERS_ALIASES

--- a/charts/homeassistant-operator/crds/ha.homeassistant.io_homeassistantcommunityrepositories.yaml
+++ b/charts/homeassistant-operator/crds/ha.homeassistant.io_homeassistantcommunityrepositories.yaml
@@ -95,8 +95,9 @@ spec:
                 description: |-
                   Ref is the tag, branch, or commit SHA to install. Pinned and explicit — this
                   operator never tracks a "latest" release automatically. Restricted to
-                  characters valid in a git ref (no URL-reserved or path-separator characters
-                  that could alter the codeload request path).
+                  characters valid in a git ref: word characters, dot, dash and slash, so
+                  branch names such as release/v1 are accepted. URL-reserved characters that
+                  could alter the codeload request path are not.
                 minLength: 1
                 pattern: ^[\w][\w.\-/]*$
                 type: string
@@ -206,7 +207,9 @@ spec:
                 description: |-
                   ResolvedTarget is the install target computed from the source repository's own
                   manifest (the integration domain, or the theme/script/template/plugin file name).
-                  Used together with Category as the conflict-detection key.
+                  Together with the referenced HomeAssistant name and Category it forms the
+                  conflict-detection key, so the same target may be installed into two
+                  different instances.
                 type: string
             type: object
         type: object

--- a/charts/homeassistant-operator/crds/ha.homeassistant.io_homeassistants.yaml
+++ b/charts/homeassistant-operator/crds/ha.homeassistant.io_homeassistants.yaml
@@ -2602,6 +2602,16 @@ spec:
                       - type
                       type: object
                     type: array
+                  gatewayClassName:
+                    default: traefik
+                    description: |-
+                      GatewayClassName names the existing GatewayClass used by the
+                      operator-created Gateway. Defaults to "traefik" when omitted. Ignored when
+                      ParentRef is set.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                   host:
                     description: Host is the hostname for the route and certificate.
                     type: string

--- a/config/crd/bases/ha.homeassistant.io_homeassistantcommunityrepositories.yaml
+++ b/config/crd/bases/ha.homeassistant.io_homeassistantcommunityrepositories.yaml
@@ -94,8 +94,9 @@ spec:
                 description: |-
                   Ref is the tag, branch, or commit SHA to install. Pinned and explicit — this
                   operator never tracks a "latest" release automatically. Restricted to
-                  characters valid in a git ref (no URL-reserved or path-separator characters
-                  that could alter the codeload request path).
+                  characters valid in a git ref: word characters, dot, dash and slash, so
+                  branch names such as release/v1 are accepted. URL-reserved characters that
+                  could alter the codeload request path are not.
                 minLength: 1
                 pattern: ^[\w][\w.\-/]*$
                 type: string
@@ -205,7 +206,9 @@ spec:
                 description: |-
                   ResolvedTarget is the install target computed from the source repository's own
                   manifest (the integration domain, or the theme/script/template/plugin file name).
-                  Used together with Category as the conflict-detection key.
+                  Together with the referenced HomeAssistant name and Category it forms the
+                  conflict-detection key, so the same target may be installed into two
+                  different instances.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/ha.homeassistant.io_homeassistants.yaml
+++ b/config/crd/bases/ha.homeassistant.io_homeassistants.yaml
@@ -2601,6 +2601,16 @@ spec:
                       - type
                       type: object
                     type: array
+                  gatewayClassName:
+                    default: traefik
+                    description: |-
+                      GatewayClassName names the existing GatewayClass used by the
+                      operator-created Gateway. Defaults to "traefik" when omitted. Ignored when
+                      ParentRef is set.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                   host:
                     description: Host is the hostname for the route and certificate.
                     type: string

--- a/config/samples/ha_v1_gateway_managed_tls.yaml
+++ b/config/samples/ha_v1_gateway_managed_tls.yaml
@@ -11,9 +11,9 @@
 # - Gateway API CRDs + a controller (e.g. Traefik v3)
 # - cert-manager + a ready Issuer/ClusterIssuer (referenced below)
 #
-# Attach to an existing Gateway via parentRef, OR set manageGateway: true to let
-# the operator create the Gateway (referencing an existing GatewayClass by name
-# equal to metadata.name — adjust to your environment).
+# Set manageGateway: true to let the operator create the Gateway and select an
+# existing GatewayClass with gatewayClassName. Alternatively, use parentRef to
+# attach the HTTPRoute to an existing Gateway.
 #
 # This example also shows spec.gateway.filters: route-level behaviors (header
 # modification, redirect, URL rewrite) applied to the route, without needing a
@@ -36,13 +36,14 @@ spec:
     issuerRef:
       name: letsencrypt-prod
       kind: ClusterIssuer
-    # Attach the HTTPRoute to an existing Gateway listener:
-    parentRef:
-      name: traefik-gateway
-      namespace: gateway
-      sectionName: https
-    # ...or let the operator create a Gateway instead of parentRef:
-    # manageGateway: true
+    manageGateway: true
+    # gatewayClassName defaults to traefik when omitted.
+    gatewayClassName: traefik
+    # Alternatively, attach the HTTPRoute to an existing Gateway listener:
+    # parentRef:
+    #   name: traefik-gateway
+    #   namespace: gateway
+    #   sectionName: https
     # secretName: my-existing-tls   # bring-your-own; overrides issuerRef
     # Route-level filters (optional): applied, in order, to the single route
     # the operator manages for this instance. Supported types:

--- a/docs/how-to/expose-with-tls.md
+++ b/docs/how-to/expose-with-tls.md
@@ -80,17 +80,26 @@ spec:
     issuerRef:
       name: ca-issuer
       kind: ClusterIssuer
-    parentRef:                 # attach to an existing Gateway listener
-      name: traefik-gateway
-      namespace: gateway
-      sectionName: https
-    # manageGateway: true      # ...or let the operator create the Gateway
+    manageGateway: true
+    gatewayClassName: traefik # existing GatewayClass provided by the platform
 ```
+
+To attach the route to an existing Gateway instead, replace `manageGateway` and
+`gatewayClassName` with a `parentRef` containing the Gateway name and, when
+needed, its namespace and listener `sectionName`. `parentRef` takes precedence
+if both forms are configured, and `gatewayClassName` never modifies an external
+Gateway.
+
+Omitting `gatewayClassName` defaults a managed Gateway to the `traefik` class.
+You can change the field declaratively; removing it restores the `traefik`
+default. Clusters using another Gateway controller should set the field
+explicitly.
 
 !!! note "What the operator does not manage"
     The operator does **not** manage the `GatewayClass` or the Ingress/Gateway
-    controller itself — those are provided by your platform. It only manages the
-    routing resources and the certificate.
+    controller itself — those are provided by your platform. `gatewayClassName`
+    only selects an existing class; it does not create or discover one. The
+    operator manages the routing resources and the certificate.
 
 
 ## Webhook

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -311,6 +311,7 @@ _Appears in:_
 | `secretName` _string_ | SecretName references a bring-your-own TLS Secret for the listener.<br />Takes precedence over IssuerRef. |  | Optional: \{\} <br /> |
 | `parentRef` _[GatewayParentRef](#gatewayparentref)_ | ParentRef references an existing Gateway/listener to attach the HTTPRoute<br />to. When empty and ManageGateway is true, the operator creates a Gateway. |  | Optional: \{\} <br /> |
 | `manageGateway` _boolean_ | ManageGateway controls whether the operator also creates a Gateway<br />resource (not just the HTTPRoute). GatewayClass and the gateway controller<br />remain the platform's responsibility. | false | Optional: \{\} <br /> |
+| `gatewayClassName` _string_ | GatewayClassName names the existing GatewayClass used by the<br />operator-created Gateway. Defaults to "traefik" when omitted. Ignored when<br />ParentRef is set. | traefik | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$` <br />Optional: \{\} <br /> |
 | `filters` _[HTTPRouteFilter](#httproutefilter) array_ | Filters are HTTP route-level behaviors (header modification, redirect, URL<br />rewrite) applied, in order, to the single HTTPRoute rule the operator<br />manages for this instance. Omitted/empty leaves the route unchanged from<br />its default shape. |  | Optional: \{\} <br /> |
 
 

--- a/internal/controller/exposure_helpers.go
+++ b/internal/controller/exposure_helpers.go
@@ -36,7 +36,10 @@ import (
 // Gateway API GroupVersionKinds the operator manages as unstructured (avoiding a
 // dependency on sigs.k8s.io/gateway-api and keeping graceful degradation simple —
 // consistent with how cert-manager Certificates are handled).
-const gatewayAPIGroup = "gateway.networking.k8s.io"
+const (
+	gatewayAPIGroup         = "gateway.networking.k8s.io"
+	defaultGatewayClassName = "traefik"
+)
 
 var (
 	httpRouteGVK = schema.GroupVersionKind{Group: gatewayAPIGroup, Version: "v1", Kind: "HTTPRoute"}
@@ -449,6 +452,10 @@ func buildHTTPPathModifier(p *hav1.HTTPPathModifier) map[string]interface{} {
 func (r *HomeAssistantReconciler) ensureManagedGateway(
 	ctx context.Context, ha *hav1.HomeAssistant, tlsSecret string,
 ) error {
+	gatewayClassName := ha.Spec.Gateway.GatewayClassName
+	if gatewayClassName == "" {
+		gatewayClassName = defaultGatewayClassName
+	}
 	gw := &unstructured.Unstructured{}
 	gw.SetGroupVersionKind(gatewayGVK)
 	gw.SetName(managedGatewayName(ha))
@@ -467,7 +474,7 @@ func (r *HomeAssistantReconciler) ensureManagedGateway(
 	}
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, gw, func() error {
 		gw.Object["spec"] = map[string]interface{}{
-			"gatewayClassName": ha.Name,
+			"gatewayClassName": gatewayClassName,
 			"listeners":        []interface{}{listener},
 		}
 		return controllerutil.SetControllerReference(ha, gw, r.Scheme)

--- a/internal/controller/exposure_helpers_test.go
+++ b/internal/controller/exposure_helpers_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -77,6 +78,142 @@ func getUnstructured(
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(gvk)
 	return u, r.Get(context.Background(), client.ObjectKey{Name: name, Namespace: "default"}, u)
+}
+
+func managedGatewayHA(name, gatewayClassName string) *hav1.HomeAssistant {
+	return &hav1.HomeAssistant{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: hav1.HomeAssistantSpec{Gateway: &hav1.GatewaySpec{
+			Enabled:          true,
+			Host:             name + ".example.com",
+			ManageGateway:    true,
+			GatewayClassName: gatewayClassName,
+		}},
+	}
+}
+
+func TestReconcileExposureManagedGatewayClass(t *testing.T) {
+	t.Run("copies a selected class without looking it up", func(t *testing.T) {
+		ha := managedGatewayHA("home", "traefik")
+		r := newExposureReconciler(t, false, ha)
+
+		if err := r.reconcileExposure(context.Background(), ha); err != nil {
+			t.Fatalf("reconcileExposure error: %v", err)
+		}
+		gateway, err := getUnstructured(t, r, gatewayGVK, managedGatewayName(ha))
+		if err != nil {
+			t.Fatalf("expected managed Gateway created: %v", err)
+		}
+		className, _, _ := unstructured.NestedString(gateway.Object, "spec", "gatewayClassName")
+		if className != "traefik" {
+			t.Fatalf("expected gatewayClassName traefik, got %q", className)
+		}
+	})
+
+	t.Run("allows two instances to share a selected class", func(t *testing.T) {
+		first := managedGatewayHA("first", "traefik")
+		second := managedGatewayHA("second", "traefik")
+		r := newExposureReconciler(t, false, first, second)
+
+		for _, ha := range []*hav1.HomeAssistant{first, second} {
+			if err := r.reconcileExposure(context.Background(), ha); err != nil {
+				t.Fatalf("reconcileExposure(%s) error: %v", ha.Name, err)
+			}
+			gateway, err := getUnstructured(t, r, gatewayGVK, managedGatewayName(ha))
+			if err != nil {
+				t.Fatalf("expected managed Gateway for %s: %v", ha.Name, err)
+			}
+			className, _, _ := unstructured.NestedString(gateway.Object, "spec", "gatewayClassName")
+			if className != "traefik" {
+				t.Fatalf("expected %s Gateway to use traefik, got %q", ha.Name, className)
+			}
+		}
+	})
+}
+
+func TestReconcileExposureManagedGatewayDefaultClass(t *testing.T) {
+	t.Run("omitted class defaults to traefik", func(t *testing.T) {
+		ha := managedGatewayHA("legacy-home", "")
+		r := newExposureReconciler(t, false, ha)
+
+		if err := r.reconcileExposure(context.Background(), ha); err != nil {
+			t.Fatalf("reconcileExposure error: %v", err)
+		}
+		gateway, err := getUnstructured(t, r, gatewayGVK, managedGatewayName(ha))
+		if err != nil {
+			t.Fatalf("expected managed Gateway created: %v", err)
+		}
+		className, _, _ := unstructured.NestedString(gateway.Object, "spec", "gatewayClassName")
+		if className != defaultGatewayClassName {
+			t.Fatalf("expected default gatewayClassName %q, got %q", defaultGatewayClassName, className)
+		}
+	})
+
+	t.Run("external parent takes precedence over managed class", func(t *testing.T) {
+		ha := managedGatewayHA("external-home", "cilium")
+		ha.Spec.Gateway.ParentRef = &hav1.GatewayParentRef{
+			Name: "shared-gateway", Namespace: "gateway-system", SectionName: "https",
+		}
+		r := newExposureReconciler(t, false, ha)
+
+		if err := r.reconcileExposure(context.Background(), ha); err != nil {
+			t.Fatalf("reconcileExposure error: %v", err)
+		}
+		if _, err := getUnstructured(t, r, gatewayGVK, managedGatewayName(ha)); err == nil {
+			t.Fatal("expected no managed Gateway when parentRef is configured")
+		}
+		route, err := getUnstructured(t, r, httpRouteGVK, ha.Name)
+		if err != nil {
+			t.Fatalf("expected HTTPRoute created: %v", err)
+		}
+		parents, _, _ := unstructured.NestedSlice(route.Object, "spec", "parentRefs")
+		if len(parents) != 1 {
+			t.Fatalf("expected one external parentRef, got %#v", parents)
+		}
+		parent, ok := parents[0].(map[string]interface{})
+		if !ok || parent["name"] != "shared-gateway" || parent["namespace"] != "gateway-system" {
+			t.Fatalf("unexpected external parentRef: %#v", parents)
+		}
+	})
+}
+
+func TestReconcileExposureManagedGatewayClassUpdatesInPlace(t *testing.T) {
+	ha := managedGatewayHA("mutable-home", "")
+	gateway := &unstructured.Unstructured{}
+	gateway.SetGroupVersionKind(gatewayGVK)
+	gateway.SetName(managedGatewayName(ha))
+	gateway.SetNamespace(ha.Namespace)
+	gateway.SetUID(types.UID("managed-gateway-uid"))
+	gateway.Object["spec"] = map[string]interface{}{}
+	r := newExposureReconciler(t, false, ha, gateway)
+
+	transitions := []struct {
+		configuredClass string
+		wantClass       string
+	}{
+		{wantClass: defaultGatewayClassName},
+		{configuredClass: "traefik", wantClass: "traefik"},
+		{configuredClass: "cilium", wantClass: "cilium"},
+		{wantClass: defaultGatewayClassName},
+	}
+	for _, transition := range transitions {
+		ha.Spec.Gateway.GatewayClassName = transition.configuredClass
+		wantClass := transition.wantClass
+		if err := r.reconcileExposure(context.Background(), ha); err != nil {
+			t.Fatalf("reconcileExposure for class %q: %v", wantClass, err)
+		}
+		current, err := getUnstructured(t, r, gatewayGVK, managedGatewayName(ha))
+		if err != nil {
+			t.Fatalf("get managed Gateway: %v", err)
+		}
+		if current.GetUID() != types.UID("managed-gateway-uid") {
+			t.Fatalf("expected Gateway UID to remain stable, got %q", current.GetUID())
+		}
+		className, _, _ := unstructured.NestedString(current.Object, "spec", "gatewayClassName")
+		if className != wantClass {
+			t.Fatalf("expected gatewayClassName %q, got %q", wantClass, className)
+		}
+	}
 }
 
 // TestReconcileExposureIngress: Ingress enabled with an issuerRef and

--- a/internal/webhook/v1/admission_envtest_test.go
+++ b/internal/webhook/v1/admission_envtest_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -39,6 +41,67 @@ import (
 
 	hav1 "github.com/przemekhys/homeassistant-operator/api/v1"
 )
+
+func TestGatewayClassNameAdmission(t *testing.T) {
+	k8sClient, _, cleanup := setupWebhookTestEnv(t)
+	defer cleanup()
+
+	tests := []struct {
+		name                    string
+		gatewayClassName        string
+		includeGatewayClassName bool
+		wantAccepted            bool
+		wantDefault             string
+	}{
+		{name: "valid", gatewayClassName: "traefik", includeGatewayClassName: true, wantAccepted: true},
+		{name: "maximum length", gatewayClassName: strings.Repeat("a", 253),
+			includeGatewayClassName: true, wantAccepted: true},
+		{name: "explicit empty", includeGatewayClassName: true, wantAccepted: false},
+		{name: "malformed", gatewayClassName: "Traefik", includeGatewayClassName: true, wantAccepted: false},
+		{name: "over maximum length", gatewayClassName: strings.Repeat("a", 254),
+			includeGatewayClassName: true, wantAccepted: false},
+		{name: "omission applies default", wantAccepted: true, wantDefault: "traefik"},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			gateway := map[string]interface{}{
+				"enabled":       true,
+				"host":          "ha.example.com",
+				"manageGateway": true,
+			}
+			if tt.includeGatewayClassName {
+				gateway["gatewayClassName"] = tt.gatewayClassName
+			}
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": hav1.GroupVersion.String(),
+				"kind":       "HomeAssistant",
+				"metadata": map[string]interface{}{
+					"name":      fmt.Sprintf("gateway-class-%d", i),
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"gateway": gateway,
+				},
+			}}
+
+			err := k8sClient.Create(context.Background(), obj)
+			if tt.wantAccepted {
+				g.Expect(err).NotTo(HaveOccurred())
+				if tt.wantDefault != "" {
+					className, found, nestedErr := unstructured.NestedString(obj.Object,
+						"spec", "gateway", "gatewayClassName")
+					g.Expect(nestedErr).NotTo(HaveOccurred())
+					g.Expect(found).To(BeTrue())
+					g.Expect(className).To(Equal(tt.wantDefault))
+				}
+			} else {
+				g.Expect(err).To(HaveOccurred())
+			}
+		})
+	}
+}
 
 // setupWebhookTestEnv spins up a real envtest API server, a real
 // ValidatingWebhookConfiguration, and a real webhook server (the same wiring

--- a/test/e2e/tls_exposure_test.go
+++ b/test/e2e/tls_exposure_test.go
@@ -140,6 +140,7 @@ spec:
       name: %s
       kind: ClusterIssuer
     manageGateway: true
+    gatewayClassName: traefik
     filters:
       - type: RequestRedirect
         requestRedirect:
@@ -152,6 +153,11 @@ spec:
               value: SAMEORIGIN
   %s`, haName, namespace, haName, clusterIssuer, utils.GetDefaultHAResourceRequests())
 		Expect(utils.ApplyYAML(haYAML, namespace)).To(Succeed())
+
+		By("Verifying the managed Gateway selects the configured class")
+		Eventually(func() string {
+			return utils.GetResourceStatus("gateway", haName+"-gateway", namespace, "{.spec.gatewayClassName}")
+		}, utils.ResourceTimeout, utils.DefaultEventuallyPollingInterval).Should(Equal("traefik"))
 
 		By("Verifying the HTTPRoute is created with the correct hostname")
 		Eventually(func() string {
@@ -202,6 +208,22 @@ spec:
 
 		Expect(utils.GetResourceStatus("pod", haName+"-0", namespace, "{.status.startTime}")).
 			To(Equal(podStartBefore), "changing spec.gateway.filters must not restart the HA pod")
+
+		By("Changing the selected GatewayClass in place")
+		Expect(utils.PatchResource("homeassistants", haName, namespace, "merge",
+			`{"spec":{"gateway":{"gatewayClassName":"cilium"}}}`)).To(Succeed())
+		Eventually(func() string {
+			return utils.GetResourceStatus("gateway", haName+"-gateway", namespace, "{.spec.gatewayClassName}")
+		}, utils.ResourceTimeout, utils.DefaultEventuallyPollingInterval).Should(Equal("cilium"))
+
+		By("Removing the selection and restoring the default class")
+		Expect(utils.PatchResource("homeassistants", haName, namespace, "merge",
+			`{"spec":{"gateway":{"gatewayClassName":null}}}`)).To(Succeed())
+		Eventually(func() string {
+			return utils.GetResourceStatus("gateway", haName+"-gateway", namespace, "{.spec.gatewayClassName}")
+		}, utils.ResourceTimeout, utils.DefaultEventuallyPollingInterval).Should(Equal("traefik"))
+		Expect(utils.GetResourceStatus("pod", haName+"-0", namespace, "{.status.startTime}")).
+			To(Equal(podStartBefore), "changing spec.gateway.gatewayClassName must not restart the HA pod")
 	})
 })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the GatewayClass used by operator-managed Gateways.
  * Defaults to the `traefik` GatewayClass when no selection is provided.
  * GatewayClass selections can be updated without replacing the existing Gateway.
  * Existing Gateway references continue to take precedence.

* **Documentation**
  * Updated TLS setup guidance, API reference material, and examples for GatewayClass configuration.

* **Validation**
  * Added validation for DNS-compatible GatewayClass names and clearer handling of invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->